### PR TITLE
Handle Case when default collection named "Collection" is not present

### DIFF
--- a/databpy/object.py
+++ b/databpy/object.py
@@ -581,9 +581,17 @@ def create_object(
     mesh = bpy.data.meshes.new(name)
     mesh.from_pydata(vertices=vertices, edges=edges, faces=faces)
     obj = bpy.data.objects.new(name, mesh)
-    if not collection:
-        collection = bpy.data.collections["Collection"]
+
+    # Link object to collection
+    if collection is None:
+        # Ensure the default collection named "Collection" exists
+        if "Collection" not in bpy.data.collections:
+            collection = bpy.data.collections.new("Collection")
+            bpy.context.scene.collection.children.link(collection)
+        else:
+            collection = bpy.data.collections["Collection"]
     collection.objects.link(obj)
+    
     return obj
 
 


### PR DESCRIPTION
This highlights the current problem:
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/262c82af-af50-4b75-9bc1-ed52b4950241" />

Disclaimer: I did not test the code locally, I just made these changes within a minimal example and then commited via the GitHub web IDE.