### PR TITLE
fix uuid mismatch when wrapping obj

### DIFF
--- a/databpy/object.py
+++ b/databpy/object.py
@@ -150,6 +150,8 @@ class BlenderObject:
         self._object_name: str = ""
 
         if isinstance(obj, Object):
+            if obj.uuid != "":
+                self._uuid = obj.uuid
             self.object = obj
         elif isinstance(obj, str):
             self.object = bpy.data.objects[obj]

--- a/databpy/object.py
+++ b/databpy/object.py
@@ -149,6 +149,9 @@ class BlenderObject:
         self._uuid: str = str(uuid1())
         self._object_name: str = ""
 
+        if not hasattr(bpy.types.Object, "uuid"):
+            register()
+
         if isinstance(obj, Object):
             if obj.uuid != "":
                 self._uuid = obj.uuid

--- a/databpy/object.py
+++ b/databpy/object.py
@@ -154,7 +154,10 @@ class BlenderObject:
                 self._uuid = obj.uuid
             self.object = obj
         elif isinstance(obj, str):
-            self.object = bpy.data.objects[obj]
+            obj = bpy.data.objects[obj]
+            if obj.uuid != "":
+                self._uuid = obj.uuid
+            self.object = obj
         elif obj is None:
             self._object_name = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databpy"
-version = "0.0.6"
+version = "0.0.7"
 description = "A data-oriented wrapper library for the Blender Python API"
 readme = "README.md"
 dependencies = ["numpy>=1.26.0,<2.0"]

--- a/tests/test_bob.py
+++ b/tests/test_bob.py
@@ -46,3 +46,8 @@ def test_bob_mismatch_uuid():
     old_uuid = obj.uuid
     bob = db.BlenderObject(obj)
     assert old_uuid == bob.uuid
+
+
+def test_register():
+    db.unregister()
+    bob = db.BlenderObject(bpy.data.objects["Cube"])

--- a/tests/test_bob.py
+++ b/tests/test_bob.py
@@ -36,3 +36,13 @@ def test_bob(snapshot):
     assert not np.allclose(pos_a, pos_b)
     assert snapshot == pos_a
     assert snapshot == pos_b
+
+
+# test that we aren't overwriting an existing UUID on an object, when wrapping it with
+# with BlenderObject
+def test_bob_mismatch_uuid():
+    bob = db.BlenderObject(bpy.data.objects["Cube"])
+    obj = bob.object
+    old_uuid = obj.uuid
+    bob = db.BlenderObject(obj)
+    assert old_uuid == bob.uuid

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.0.6"
+version = "0.0.7"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.0.5"
+version = "0.0.6"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
If we wrap an object in `BlenderObject` that already has a `UUID`, then we now take on that existing `UUID` instead of re-assigning one leading to loss of sync with databases.