### PR TITLE
Create custom String `Index Switch`

### DIFF
--- a/databpy/nodes.py
+++ b/databpy/nodes.py
@@ -228,6 +228,7 @@ def custom_string_iswitch(
         return tree
 
     tree = new_tree(name=name, geometry=False)
+    tree.color_tag = "CONVERTER"
 
     # try creating the node group, otherwise on fail cleanup the created group and
     # report the error

--- a/databpy/nodes.py
+++ b/databpy/nodes.py
@@ -223,11 +223,13 @@ def custom_string_iswitch(
     Creates a node group containing a `Index Switch` node with all the given values.
     """
 
-    tree = bpy.data.node_groups.get(name)
-    if tree:
-        return tree
-
-    tree = new_tree(name=name, geometry=False)
+    # dont' attempt to return an already existing node tree. If a user is requesting a
+    # new one they are likely passing in a new list, so we have to createa a new one
+    # to ensure we are using the new iterables
+    tree = new_tree(name=name, geometry=False, fallback=False)
+    # name might have originally been the same, but on creation it might be name.001 or
+    # something similar so we just grab the name from the tree
+    name = tree.name
     tree.color_tag = "CONVERTER"
 
     # try creating the node group, otherwise on fail cleanup the created group and

--- a/databpy/nodes.py
+++ b/databpy/nodes.py
@@ -1,5 +1,5 @@
 import bpy
-from typing import List
+from typing import List, Iterable
 import re
 import time
 import warnings
@@ -12,6 +12,22 @@ class NodeGroupCreationError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
+
+def get_output(group):
+    return group.nodes[
+        bpy.app.translations.pgettext_data(
+            "Group Output",
+        )
+    ]
+
+
+def get_input(group):
+    return group.nodes[
+        bpy.app.translations.pgettext_data(
+            "Group Input",
+        )
+    ]
 
 
 def deduplicate_node_trees(node_trees: List[str]):
@@ -169,3 +185,90 @@ def append_from_blend(
                     use_recursive=True,
                 )
         return bpy.data.node_groups[name]
+
+
+def new_tree(
+    name: str = "Geometry Nodes",
+    geometry: bool = True,
+    input_name: str = "Geometry",
+    output_name: str = "Geometry",
+    fallback: bool = True,
+) -> bpy.types.NodeTree:
+    tree = bpy.data.node_groups.get(name)
+    # if the group already exists, return it and don't create a new one
+    if tree and fallback:
+        return tree
+
+    # create a new group for this particular name and do some initial setup
+    tree = bpy.data.node_groups.new(name, "GeometryNodeTree")
+    input_node = tree.nodes.new("NodeGroupInput")
+    output_node = tree.nodes.new("NodeGroupOutput")
+    input_node.location.x = -200 - input_node.width
+    output_node.location.x = 200
+    if geometry:
+        tree.interface.new_socket(
+            input_name, in_out="INPUT", socket_type="NodeSocketGeometry"
+        )
+        tree.interface.new_socket(
+            output_name, in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        tree.links.new(output_node.inputs[0], input_node.outputs[0])
+    return tree
+
+
+def custom_string_iswitch(
+    name: str, values: Iterable[str], attr_name: str = "attr_id"
+) -> bpy.types.NodeTree:
+    """
+    Creates a node group containing a `Index Switch` node with all the given values.
+    """
+
+    tree = bpy.data.node_groups.get(name)
+    if tree:
+        return tree
+
+    tree = new_tree(name=name, geometry=False)
+
+    # try creating the node group, otherwise on fail cleanup the created group and
+    # report the error
+    try:
+        link = tree.links.new
+        node_input = get_input(tree)
+        socket_in = tree.interface.new_socket(
+            attr_name, in_out="INPUT", socket_type="NodeSocketInt"
+        )
+        socket_in.name = attr_name
+        node_output = get_output(tree)
+        socket_out = tree.interface.new_socket(
+            attr_name, in_out="OUTPUT", socket_type="NodeSocketString"
+        )
+        socket_out.name = "String"
+
+        node_iswitch: bpy.types.GeometryNodeIndexSwitch = tree.nodes.new(  # type: ignore
+            "GeometryNodeIndexSwitch"
+        )
+        node_iswitch.data_type = "STRING"
+        link(node_input.outputs[socket_in.identifier], node_iswitch.inputs["Index"])
+
+        for i, item in enumerate(values):
+            # the node starts with 2 items alread, so we only create new items
+            # if they are above that
+            if i > 1:
+                node_iswitch.index_switch_items.new()
+
+            node_iswitch.inputs[int(i + 1)].default_value = item
+
+        link(
+            node_iswitch.outputs["Output"],
+            node_output.inputs[socket_out.identifier],
+        )
+
+        return tree
+
+    # if something broke when creating the node group, delete whatever was created
+    except Exception as e:
+        node_name = tree.name
+        bpy.data.node_groups.remove(tree)
+        raise NodeGroupCreationError(
+            f"Unable to make node group: {node_name}.\nError: {e}"
+        )

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,63 @@
+import pytest
+import bpy
+import databpy as db
+from databpy.nodes import custom_string_iswitch, NodeGroupCreationError
+
+
+def test_custom_string_iswitch_basic():
+    """Test basic creation of string index switch node group"""
+
+    tree = custom_string_iswitch("TestSwitch", ["X", "Y", "Z"])
+
+    assert tree.name == "TestSwitch"
+    assert isinstance(tree, bpy.types.NodeTree)
+
+    # Test input/output sockets
+    assert tree.interface.items_tree["attr_id"].in_out == "INPUT"
+    assert tree.interface.items_tree["String"].in_out == "OUTPUT"
+
+    # Test node presence and configuration
+    iswitch = next(n for n in tree.nodes if n.type == "INDEX_SWITCH")
+    assert iswitch.data_type == "STRING"
+    assert len(iswitch.index_switch_items) == 3
+
+
+def test_custom_string_iswitch_values():
+    """Test that input values are correctly assigned"""
+    values = ["Chain_A", "Chain_B", "Chain_C", "Chain_D"]
+    tree = custom_string_iswitch("ValueTest", values, "chain")
+
+    iswitch = next(n for n in tree.nodes if n.type == "INDEX_SWITCH")
+
+    # Check all values are assigned correctly
+    for i, val in enumerate(values):
+        assert iswitch.inputs[i + 1].default_value == val
+
+
+def test_custom_string_iswitch_reuse():
+    """Test that existing node group is returned if name exists"""
+    tree1 = custom_string_iswitch("ReuseTest", ["A", "B"])
+    tree2 = custom_string_iswitch("ReuseTest", ["X", "Y"])
+
+    assert tree1 == tree2
+    assert tree1.name == "ReuseTest"
+
+
+def test_custom_string_iswitch_minimal():
+    """Test creation with default values"""
+    tree = custom_string_iswitch("MinimalTest", ["A", "B", "C"])
+
+    iswitch = next(n for n in tree.nodes if n.type == "INDEX_SWITCH")
+    assert len(iswitch.index_switch_items) == 3
+    assert iswitch.inputs[1].default_value == "A"
+    assert iswitch.inputs[2].default_value == "B"
+    assert iswitch.inputs[3].default_value == "C"
+
+
+def test_long_list():
+    """Test that a long list of values is correctly handled"""
+    tree = custom_string_iswitch(
+        "LongListTest", [str(x) for x in range(1_000)], "chain"
+    )
+    for i, val in enumerate(range(1_000)):
+        assert tree.nodes["Index Switch"].inputs[i + 1].default_value == str(val)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -61,3 +61,9 @@ def test_long_list():
     )
     for i, val in enumerate(range(1_000)):
         assert tree.nodes["Index Switch"].inputs[i + 1].default_value == str(val)
+
+
+def test_raises_error():
+    """Test that an error is raised if the node group already exists"""
+    with pytest.raises(NodeGroupCreationError):
+        custom_string_iswitch("TestSwitch", range(10))

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -34,13 +34,13 @@ def test_custom_string_iswitch_values():
         assert iswitch.inputs[i + 1].default_value == val
 
 
-def test_custom_string_iswitch_reuse():
+def test_custom_string_iswitch_name_duplication():
     """Test that existing node group is returned if name exists"""
     tree1 = custom_string_iswitch("ReuseTest", ["A", "B"])
     tree2 = custom_string_iswitch("ReuseTest", ["X", "Y"])
 
-    assert tree1 == tree2
     assert tree1.name == "ReuseTest"
+    assert tree1.name + ".001" == tree2.name
 
 
 def test_custom_string_iswitch_minimal():

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11.0, <3.12"
 
 [[package]]
@@ -246,7 +247,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -316,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.0.7"
+version = "0.0.9"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },
@@ -346,7 +347,7 @@ requires-dist = [
     { name = "bpy", marker = "extra == 'bpy'", specifier = ">=4.2" },
     { name = "fake-bpy-module", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'docs'" },
-    { name = "numpy", specifier = ">=1.24.0,<2.0" },
+    { name = "numpy", specifier = ">=1.26.0,<2.0" },
     { name = "polars", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'docs'" },
     { name = "pytest", marker = "extra == 'test'" },
@@ -354,6 +355,7 @@ requires-dist = [
     { name = "quartodoc", marker = "extra == 'docs'" },
     { name = "syrupy", marker = "extra == 'test'" },
 ]
+provides-extras = ["bpy", "test", "dev", "docs"]
 
 [[package]]
 name = "debugpy"
@@ -515,7 +517,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },


### PR DESCRIPTION
Creates a node group with an `Index Switch` inside, that is populated with a iterable of string values. This can then be used inside node trees, especially for use in the `For Each Element` zone.

![Image](https://github.com/user-attachments/assets/566efd02-bde6-4ea6-ae90-68904fba1efd)

![Image](https://github.com/user-attachments/assets/ee664ded-24d5-4dc6-8732-4825e46371fc)

![Image](https://github.com/user-attachments/assets/96ad294d-5eac-4ef3-82b8-747f20bdd8d6)
