### PR TITLE
add __version__

### DIFF
--- a/databpy/__init__.py
+++ b/databpy/__init__.py
@@ -1,3 +1,8 @@
+import importlib.metadata
+
+# Get the version of the package
+__version__: str = importlib.metadata.version(__name__)
+
 from .object import (
     ObjectTracker,
     BlenderObject,


### PR DESCRIPTION
This will for allow:
```py
import databpy as db
print(db.__version__)
```
I did not test the code yet, as I did not figure out an easy way to uninstall my currently installed databpy version and test this version instead.