### PR TITLE
Support pathlib and automatically add NodeTree to append_from_blend

### DIFF
--- a/databpy/__init__.py
+++ b/databpy/__init__.py
@@ -1,6 +1,3 @@
-import importlib.metadata
-
-
 from .object import (
     ObjectTracker,
     BlenderObject,

--- a/databpy/__init__.py
+++ b/databpy/__init__.py
@@ -1,3 +1,6 @@
+import importlib.metadata
+
+
 from .object import (
     ObjectTracker,
     BlenderObject,
@@ -7,6 +10,7 @@ from .object import (
     bdo,
 )
 from .vdb import import_vdb
+from . import nodes
 from .nodes import utils
 import bpy
 from .addon import register, unregister

--- a/databpy/nodes/appending.py
+++ b/databpy/nodes/appending.py
@@ -87,7 +87,7 @@ def append_from_blend(
             warnings.simplefilter("ignore")
             with DuplicatePrevention():
                 # Append from NodeTree directory inside blend file
-                directory = str(filepath) + "/NodeTree/"
+                directory = str(Path(filepath) / "NodeTree")
                 bpy.ops.wm.append(
                     "EXEC_DEFAULT", 
                     directory=directory,

--- a/databpy/nodes/appending.py
+++ b/databpy/nodes/appending.py
@@ -75,7 +75,6 @@ class DuplicatePrevention:
             end_time = time.time()
             print(f"De-duplication time: {end_time - self.start_time:.2f} seconds")
 
-
 def append_from_blend(
     name: str, filepath: str | Path, link: bool = False
 ) -> bpy.types.NodeTree:
@@ -87,9 +86,11 @@ def append_from_blend(
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with DuplicatePrevention():
+                # Append from NodeTree directory inside blend file
+                directory = str(filepath) + "/NodeTree/"
                 bpy.ops.wm.append(
-                    "EXEC_DEFAULT",
-                    directory=str(filepath),
+                    "EXEC_DEFAULT", 
+                    directory=directory,
                     filename=name,
                     link=link,
                     use_recursive=True,

--- a/databpy/nodes/appending.py
+++ b/databpy/nodes/appending.py
@@ -3,7 +3,7 @@ import bpy
 import re
 import time
 import warnings
-
+from pathlib import Path
 
 def deduplicate_node_trees(node_trees: List[bpy.types.NodeTree]):
     # Compile the regex pattern for matching a suffix of a dot followed by 3 numbers
@@ -77,9 +77,10 @@ class DuplicatePrevention:
 
 
 def append_from_blend(
-    name: str, filepath: str, link: bool = False
+    name: str, filepath: str | Path, link: bool = False
 ) -> bpy.types.NodeTree:
     "Append a Geometry Nodes node tree from the given .blend file"
+    print(f"Appending {name} from {filepath}")
     try:
         return bpy.data.node_groups[name]
     except KeyError:
@@ -88,7 +89,7 @@ def append_from_blend(
             with DuplicatePrevention():
                 bpy.ops.wm.append(
                     "EXEC_DEFAULT",
-                    directory=filepath,
+                    directory=str(filepath),
                     filename=name,
                     link=link,
                     use_recursive=True,

--- a/databpy/nodes/appending.py
+++ b/databpy/nodes/appending.py
@@ -1,9 +1,11 @@
-from typing import List
-import bpy
 import re
 import time
 import warnings
 from pathlib import Path
+from typing import List
+
+import bpy
+
 
 def deduplicate_node_trees(node_trees: List[bpy.types.NodeTree]):
     # Compile the regex pattern for matching a suffix of a dot followed by 3 numbers
@@ -75,11 +77,15 @@ class DuplicatePrevention:
             end_time = time.time()
             print(f"De-duplication time: {end_time - self.start_time:.2f} seconds")
 
+
 def append_from_blend(
     name: str, filepath: str | Path, link: bool = False
 ) -> bpy.types.NodeTree:
     "Append a Geometry Nodes node tree from the given .blend file"
-    print(f"Appending {name} from {filepath}")
+    # to access the nodes we need to specify the "NodeTree" folder but this isn't a real
+    # folder, just for accessing when appending. Ensure that the filepath ends with "NodeTree"
+    filepath = str(Path(filepath)).removesuffix("NodeTree")
+    filepath = str(Path(filepath) / "NodeTree")
     try:
         return bpy.data.node_groups[name]
     except KeyError:
@@ -87,10 +93,9 @@ def append_from_blend(
             warnings.simplefilter("ignore")
             with DuplicatePrevention():
                 # Append from NodeTree directory inside blend file
-                directory = str(Path(filepath) / "NodeTree")
                 bpy.ops.wm.append(
-                    "EXEC_DEFAULT", 
-                    directory=directory,
+                    "EXEC_DEFAULT",
+                    directory=filepath,
                     filename=name,
                     link=link,
                     use_recursive=True,

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.0.16"
+version = "0.0.19"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Closes https://github.com/BradyAJohnston/databpy/issues/37

This is currently not backwards compatible. This works:
```py
from pathlib import Path
import databpy as db

blend_file = Path.home() / "projects/bpy-gallery/docs/cube_gn_position.blend"
node_group_name = "gn_place_spheres"

node_groupX = db.nodes.append_from_blend(node_group_name, blend_file)

for node in node_groupX.nodes:
    print(node.name)
``` 

and this code won't work anymore:
```py
from pathlib import Path
import databpy as db

blend_file = Path.home() / "projects/bpy-gallery/docs/cube_gn_position.blend"
node_group_name = "gn_place_spheres"

# Append the node group
node_group_dir = str(blend_file) + "/NodeTree/"
node_group = db.nodes.append_from_blend(node_group_name, node_group_dir)

# Print contents
print(f"Nodes in node group '{node_group_name}':")
for node in node_group.nodes:
    print(node.name)
```

Screenshot:
![image](https://github.com/user-attachments/assets/3477706f-fe2f-4be9-b9b3-bf068725c12f)
