### PR TITLE
Handle MemoryError when looking up object

### DIFF
--- a/databpy/object.py
+++ b/databpy/object.py
@@ -217,7 +217,7 @@ class BlenderObject:
             obj = bpy.data.objects[self._object_name]
             if obj.uuid != self.uuid:
                 obj = get_from_uuid(self.uuid)
-        except KeyError:
+        except (KeyError, MemoryError):
             obj = get_from_uuid(self.uuid)
             self._object_name = obj.name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databpy"
-version = "0.3.0"
+version = "0.3.1"
 description = "A data-oriented wrapper library for the Blender Python API"
 readme = "README.md"
 dependencies = ["numpy>=1.24.0,<2.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
`MemoryError` is occasionally being thrown when looking up object, so add it to list of exceptions to handle.

https://github.com/BradyAJohnston/MolecularNodes/actions/runs/18537199363/job/52835278618?pr=995