### PR TITLE
WIP: Modifier Interface Helper

### DIFF
--- a/databpy/__init__.py
+++ b/databpy/__init__.py
@@ -1,44 +1,46 @@
-from .object import (
-    ObjectTracker,
-    BlenderObjectBase,
-    BlenderObjectAttribute,
-    BlenderObject,
-    BOB,
-    create_object,
-    create_bob,
-    create_mesh_object,
-    create_curves_object,
-    create_pointcloud_object,
-    LinkedObjectError,
-    bdo,
-)
-from .vdb import import_vdb
 from . import nodes
-from .nodes import utils
 from .addon import register, unregister
-from .utils import centre, lerp
-from .collection import create_collection
 from .array import AttributeArray
 from .attribute import (
-    named_attribute,
-    store_named_attribute,
-    remove_named_attribute,
-    list_attributes,
-    evaluate_object,
     Attribute,
+    AttributeDomain,
+    AttributeDomains,
+    AttributeMismatchError,
     AttributeType,
     AttributeTypeInfo,
     AttributeTypes,
-    AttributeDomains,
-    AttributeDomain,
     NamedAttributeError,
-    AttributeMismatchError,
+    evaluate_object,
+    list_attributes,
+    named_attribute,
+    remove_named_attribute,
+    store_named_attribute,
 )
+from .collection import create_collection
+from .modifier import NodesModifierInterface
+from .nodes import utils
+from .object import (
+    BOB,
+    BlenderObject,
+    BlenderObjectAttribute,
+    BlenderObjectBase,
+    LinkedObjectError,
+    ObjectTracker,
+    bdo,
+    create_bob,
+    create_curves_object,
+    create_mesh_object,
+    create_object,
+    create_pointcloud_object,
+)
+from .utils import centre, lerp
+from .vdb import import_vdb
 
 __all__ = [
     "ObjectTracker",
     "BlenderObjectBase",
     "BlenderObjectAttribute",
+    "NodesModifierInterface",
     "BlenderObject",
     "BOB",
     "create_object",

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -85,7 +85,7 @@ class NodesModifierInterface(BlenderObjectBase):
         _trigger_mesh_update(self.object)
 
     def _key_attr_name(self, name: str) -> str:
-        return "{}_attribute_attribute".format(self.get_id_from_name(name))
+        return "{}_attribute_name".format(self.get_id_from_name(name))
 
     def get_attr_name(self, name: str) -> str:
         return self.modifier[self._key_attr_name(name)]
@@ -96,10 +96,10 @@ class NodesModifierInterface(BlenderObjectBase):
     def _key_use_att(self, name: str) -> str:
         return "{}_use_attribute".format(self.get_id_from_name(name))
 
-    def get_use_attr(self, name: str):
+    def get_attr_use(self, name: str):
         return self.modifier[self._key_use_att(name)]
 
-    def set_use_att(self, name: str, value: bool) -> None:
+    def set_attr_use(self, name: str, value: bool) -> None:
         self.modifier[self._key_use_att(name)] = value
 
     def list_inputs(self) -> list[str]:

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -49,6 +49,11 @@ class NodesModifierInterface(BlenderObjectBase):
             raise RuntimeError("Tree not found")
         return tree
 
+    @tree.setter
+    def tree(self, value: bpy.types.NodeTree) -> None:
+        assert isinstance(value, bpy.types.NodeTree)
+        self.modifier.node_group = value
+
     @property
     def tree_interface(self) -> bpy.types.NodeTreeInterface:
         interface = self.tree.interface

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -1,0 +1,78 @@
+import bpy
+from .object import BlenderObjectBase
+
+
+VALUE_TYPES = int | float | bool
+
+
+class GeometryNodesModifier(BlenderObjectBase):
+    def __init__(self, modifier: bpy.types.NodesModifier):
+        super().__init__(modifier.id_data)  # type: ignore
+        self._modifier_name = modifier.name
+
+    @property
+    def name(self) -> str:
+        return self.modifier.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.modifier.name = value
+        self._modifier_name = value
+
+    @property
+    def modifier(self) -> bpy.types.Modifier:
+        return self.object.modifiers[self._modifier_name]
+
+    @property
+    def tree(self) -> bpy.types.GeometryNodeTree:
+        return self.modifier.node_group  # type: ignore
+
+    def get_id_from_name(self, name: str) -> str:
+        if not hasattr(self.tree, "interface"):
+            raise RuntimeError
+        if not hasattr(self.tree.interface, "items_tree"):
+            raise RuntimeError
+        item = self.tree.interface.items_tree.get(name)
+        if not isinstance(item, bpy.types.NodeTreeInterfaceItem):
+            raise RuntimeError
+        return item.identifier  # type: ignore
+
+    def get_value(self, name: str) -> VALUE_TYPES:
+        return self.modifier[self.get_id_from_name(name)]
+
+    def set_value(self, name: str, value: VALUE_TYPES) -> None:
+        self.modifier[self.get_id_from_name(name)] = value
+        # we can manually trigger an update of the scene if it is a mesh object
+        # by just re-writing the coordinates for a single vertex which properly
+        # triggers a refresh of the 3D scene
+        if hasattr(self.object.data, "vertices"):
+            try:
+                self.object.data.vertices[0].co = self.object.data.vertices[0].co  # type: ignore
+            except Exception as e:
+                print(e)
+
+    def list_inputs(self) -> list[str]:
+        """Return list of inputs that can accept and return values"""
+        possible_inputs: list[str] = []
+        for item in self.tree.interface.items_tree:  # type: ignore
+            if item.in_out != "INPUT":  # type: ignore
+                continue
+            try:
+                self.modifier[item.identifier]  # type: ignore
+            except KeyError:
+                continue
+
+            possible_inputs.append(item.name)  # type: ignore
+
+        return possible_inputs
+
+    def _ipython_key_completions_(self) -> list[str]:
+        return self.list_inputs()
+
+    def __getitem__(self, name: str) -> VALUE_TYPES:
+        if not isinstance(name, str):
+            raise ValueError("Input name must be a string")
+        return self.get_value(name)
+
+    def __setitem__(self, name: str, value: VALUE_TYPES) -> None:
+        self.set_value(name, value)

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -1,11 +1,27 @@
 import bpy
+
 from .object import BlenderObjectBase
 
+POSSIBLE_TYPES = int | float | bool
 
-VALUE_TYPES = int | float | bool
+
+def _trigger_mesh_update(obj: bpy.types.Object) -> None:
+    data = obj.data
+    if data is None or not isinstance(data, bpy.types.Mesh):
+        raise RuntimeError("Object data is None")
+
+    data.update()
+    # we can manually trigger an update of the scene if it is a mesh object
+    # by just re-writing the coordinates for a single vertex which properly
+    # triggers a refresh of the 3D scene
+    try:
+        vert = data.vertices[0]  # type: ignore
+        vert.co = list(vert.co)  # type: ignore
+    except Exception as e:
+        print(e)
 
 
-class GeometryNodesModifier(BlenderObjectBase):
+class NodesModifierInterface(BlenderObjectBase):
     def __init__(self, modifier: bpy.types.NodesModifier):
         super().__init__(modifier.id_data)  # type: ignore
         self._modifier_name = modifier.name
@@ -20,59 +36,72 @@ class GeometryNodesModifier(BlenderObjectBase):
         self._modifier_name = value
 
     @property
-    def modifier(self) -> bpy.types.Modifier:
-        return self.object.modifiers[self._modifier_name]
+    def modifier(self) -> bpy.types.NodesModifier:
+        mod = self.object.modifiers[self._modifier_name]
+        if not isinstance(mod, bpy.types.NodesModifier):
+            raise TypeError("Modifier is not a NodesModifier")
+        return mod
 
     @property
-    def tree(self) -> bpy.types.GeometryNodeTree:
-        return self.modifier.node_group  # type: ignore
+    def tree(self) -> bpy.types.NodeTree:
+        tree = self.modifier.node_group
+        if tree is None:
+            raise RuntimeError("Tree not found")
+        return tree
+
+    @property
+    def tree_interface(self) -> bpy.types.NodeTreeInterface:
+        interface = self.tree.interface
+        if interface is None:
+            raise RuntimeError("Interface not found")
+        return interface
+
+    @property
+    def input_sockets(self) -> list[bpy.types.NodeTreeInterfaceSocket]:
+        return [
+            item
+            for item in self.tree_interface.items_tree
+            if isinstance(item, bpy.types.NodeTreeInterfaceSocket)
+            and item.in_out == "INPUT"
+        ]
 
     def get_id_from_name(self, name: str) -> str:
-        if not hasattr(self.tree, "interface"):
-            raise RuntimeError
-        if not hasattr(self.tree.interface, "items_tree"):
-            raise RuntimeError
-        item = self.tree.interface.items_tree.get(name)
-        if not isinstance(item, bpy.types.NodeTreeInterfaceItem):
-            raise RuntimeError
-        return item.identifier  # type: ignore
+        if not hasattr(self.tree, "interface") or self.tree.interface is None:
+            raise RuntimeError("Interface not found")
 
-    def get_value(self, name: str) -> VALUE_TYPES:
+        for item in self.input_sockets:
+            if item.in_out == "INPUT" and item.name == name:
+                return item.identifier
+
+        raise RuntimeError(f"Input socket not found: {name=}")
+
+    def get_value(self, name: str) -> POSSIBLE_TYPES:
         return self.modifier[self.get_id_from_name(name)]
 
-    def set_value(self, name: str, value: VALUE_TYPES) -> None:
+    def set_value(self, name: str, value: POSSIBLE_TYPES) -> None:
         self.modifier[self.get_id_from_name(name)] = value
-        # we can manually trigger an update of the scene if it is a mesh object
-        # by just re-writing the coordinates for a single vertex which properly
-        # triggers a refresh of the 3D scene
-        if hasattr(self.object.data, "vertices"):
-            try:
-                self.object.data.vertices[0].co = self.object.data.vertices[0].co  # type: ignore
-            except Exception as e:
-                print(e)
+        _trigger_mesh_update(self.object)
+
+    def get_default_attribute(self, name: str) -> str:
+        return self.modifier[self.get_id_from_name(name)]
 
     def list_inputs(self) -> list[str]:
-        """Return list of inputs that can accept and return values"""
-        possible_inputs: list[str] = []
-        for item in self.tree.interface.items_tree:  # type: ignore
-            if item.in_out != "INPUT":  # type: ignore
-                continue
+        """Return list of inputs names that can accept and return values"""
+        input_names: list[str] = []
+        for item in self.input_sockets:
             try:
-                self.modifier[item.identifier]  # type: ignore
+                self.modifier[item.identifier]
             except KeyError:
                 continue
+            input_names.append(item.name)
 
-            possible_inputs.append(item.name)  # type: ignore
-
-        return possible_inputs
+        return input_names
 
     def _ipython_key_completions_(self) -> list[str]:
         return self.list_inputs()
 
-    def __getitem__(self, name: str) -> VALUE_TYPES:
-        if not isinstance(name, str):
-            raise ValueError("Input name must be a string")
+    def __getitem__(self, name: str) -> POSSIBLE_TYPES:
         return self.get_value(name)
 
-    def __setitem__(self, name: str, value: VALUE_TYPES) -> None:
+    def __setitem__(self, name: str, value: POSSIBLE_TYPES) -> None:
         self.set_value(name, value)

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -105,3 +105,7 @@ class NodesModifierInterface(BlenderObjectBase):
 
     def __setitem__(self, name: str, value: POSSIBLE_TYPES) -> None:
         self.set_value(name, value)
+
+    # might be able to get tab completion in Blender using this?
+    def __dir__(self) -> list[str]:
+        return self.list_inputs()

--- a/databpy/modifier.py
+++ b/databpy/modifier.py
@@ -84,8 +84,23 @@ class NodesModifierInterface(BlenderObjectBase):
         self.modifier[self.get_id_from_name(name)] = value
         _trigger_mesh_update(self.object)
 
-    def get_default_attribute(self, name: str) -> str:
-        return self.modifier[self.get_id_from_name(name)]
+    def _key_attr_name(self, name: str) -> str:
+        return "{}_attribute_attribute".format(self.get_id_from_name(name))
+
+    def get_attr_name(self, name: str) -> str:
+        return self.modifier[self._key_attr_name(name)]
+
+    def set_attr_name(self, name: str, value: str) -> None:
+        self.modifier[self._key_attr_name(name)] = value
+
+    def _key_use_att(self, name: str) -> str:
+        return "{}_use_attribute".format(self.get_id_from_name(name))
+
+    def get_use_attr(self, name: str):
+        return self.modifier[self._key_use_att(name)]
+
+    def set_use_att(self, name: str, value: bool) -> None:
+        self.modifier[self._key_use_att(name)] = value
 
     def list_inputs(self) -> list[str]:
         """Return list of inputs names that can accept and return values"""

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -1,17 +1,37 @@
 import bpy
+import pytest
 
 import databpy as db
 
 
 def test_modifier():
     cube = bpy.data.objects["Cube"]
+    modifier = cube.modifiers.new("GeometryNodes", "NODES")
+    assert isinstance(modifier, bpy.types.NodesModifier)
     tree = db.nodes.new_tree()
     tree.interface.new_socket(  # type: ignore
         name="Count", in_out="INPUT", socket_type="NodeSocketInt"
     ).default_value = 3
-    mod = db.NodesModifierInterface(cube.modifiers.new("GeometryNodes", "NODES"))  # type: ignore
+    mod = db.NodesModifierInterface(modifier)
+    with pytest.raises(RuntimeError):
+        mod.tree
     mod.tree = tree
+    assert mod.name == "GeometryNodes"
+    mod.name = "New Name"
+    assert mod.name == "New Name"
 
     assert mod["Count"] == 3
     mod["Count"] = 4
     assert mod["Count"] == 4
+
+    assert mod.list_inputs() == ["Count"]
+    assert mod.list_inputs() == mod._ipython_key_completions_()
+    assert mod.list_inputs() == dir(mod)
+
+    with pytest.raises(ValueError):
+        mod.get_id_from_name("non_existant_input")
+
+    wrong_mod = cube.modifiers.new(name="test", type="NORMAL_EDIT")
+
+    with pytest.raises(AssertionError):
+        db.NodesModifierInterface(wrong_mod)  # type: ignore

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -28,10 +28,16 @@ def test_modifier():
     assert mod.list_inputs() == mod._ipython_key_completions_()
     assert mod.list_inputs() == dir(mod)
 
-    assert mod._key_use_att == "Socket_1_use_attribute"
-    assert mod._key_attr_name == "Socket_1_attribute_name"
+    assert mod._key_use_att("Count") == "Socket_2_use_attribute"
+    assert mod._key_attr_name("Count") == "Socket_2_attribute_name"
 
-    assert mod.get_attr_name("Count") == "Something"
+    assert mod.get_attr_name("Count") == ""
+    mod.set_attr_name("Count", "is_peptide")
+    assert mod.get_attr_name("Count") == "is_peptide"
+
+    assert not mod.get_attr_use("Count")
+    mod.set_attr_use("Count", True)
+    assert mod.get_attr_use("Count")
 
     with pytest.raises(ValueError):
         mod.get_id_from_name("non_existant_input")

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -28,6 +28,11 @@ def test_modifier():
     assert mod.list_inputs() == mod._ipython_key_completions_()
     assert mod.list_inputs() == dir(mod)
 
+    assert mod._key_use_att == "Socket_1_use_attribute"
+    assert mod._key_attr_name == "Socket_1_attribute_name"
+
+    assert mod.get_attr_name("Count") == "Something"
+
     with pytest.raises(ValueError):
         mod.get_id_from_name("non_existant_input")
 

--- a/tests/test_modifier.py
+++ b/tests/test_modifier.py
@@ -1,0 +1,17 @@
+import bpy
+
+import databpy as db
+
+
+def test_modifier():
+    cube = bpy.data.objects["Cube"]
+    tree = db.nodes.new_tree()
+    tree.interface.new_socket(  # type: ignore
+        name="Count", in_out="INPUT", socket_type="NodeSocketInt"
+    ).default_value = 3
+    mod = db.NodesModifierInterface(cube.modifiers.new("GeometryNodes", "NODES"))  # type: ignore
+    mod.tree = tree
+
+    assert mod["Count"] == 3
+    mod["Count"] = 4
+    assert mod["Count"] == 4

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.5.1"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Adds a modifier interface helper. Currently you have to use `Socket_*` identifiers to get and set values from a GN modifier due to RNA limitations. This helper class allows name-based getting and setting.

- **initial helper class for modifier access**
- **satisfy type checking**
