### PR TITLE
Cleanup attribute enums and types

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build Docs
         run: |
-            uv sync --all-extras --dev
+            uv sync --all-extras
             uv pip install -e .
             cd docs
             uv run -m quartodoc build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install ruff
         run: pip install ruff
       - name: Check code formatting

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -20,7 +20,8 @@ jobs:
                 version: ${{ matrix.version }}
             - name: Install in Blender
               run: |
-                blender -b -P tests/python.py -- -m pip install ".[dev]"
+                blender -b -P tests/python.py -- -m pip install --upgrade pip
+                blender -b -P tests/python.py -- -m pip install . --group dev
             - name: Run Tests
               run: |
                 blender -b -P tests/run.py -- -vv tests --cov --cov-report=xml

--- a/.github/workflows/test-in-blender.yml
+++ b/.github/workflows/test-in-blender.yml
@@ -22,5 +22,6 @@ jobs:
           version: ${{ matrix.version }}
       - name: Install and Test
         run: |
-          blender -b -P tests/python.py -- -m pip install -e ".[dev]"
+          blender -b -P tests/python.py -- -m pip install --upgrade pip
+          blender -b -P tests/python.py -- -m pip install -e . --group dev
           blender -b -P tests/run.py -- -vv

--- a/.github/workflows/test-in-blender.yml
+++ b/.github/workflows/test-in-blender.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        version: ["5.1", "5.2", "daily"]
+        version: ["5.2", "daily"]
         os: [macos-14, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        version: ["5.1", "5.2"]
+        version: ["5.2", "5.3"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
@@ -34,11 +34,11 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.os == 'macos-latest' && matrix.version == '5.1'
+        if: matrix.os == 'macos-latest' && matrix.version == '5.2'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: coverage.xml
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'macos-latest' && matrix.version == '5.1'
+        if: matrix.os == 'macos-latest' && matrix.version == '5.2'
         uses: codecov/codecov-action@v3

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -93,6 +93,7 @@ quartodoc:
         - create_pointcloud_object
         - create_bob
         - evaluate_object
+        - GeometrySet
         - BlenderObject
         - BlenderObjectAttribute
         - BlenderObjectBase

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -18,6 +18,8 @@ website:
         text: Attributes
       - href: api/index.qmd
         text: API
+      - href: changelog.qmd
+        text: Changelog
     tools:
       - icon: github
         href: https://github.com/BradyAJohnston/databpy

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,1 +1,1 @@
-version: 0.7.0
+version: 0.8.0

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -1,0 +1,110 @@
+---
+title: Changelog
+toc: true
+---
+
+## 0.8.0 (unreleased)
+
+Support for the new attribute types introduced in Blender 5.2, alongside a cleanup
+of the attribute typing system. Requires `bpy >= 5.2`.
+
+### Added
+
+- Support for the new Blender 5.2 attribute types:
+  - `FLOAT4` — 4D float vectors ([`Float4Attribute`](https://docs.blender.org/api/current/bpy.types.Float4Attribute.html))
+  - `INT16_2D` — 2D 16-bit signed integer vectors ([`Short2Attribute`](https://docs.blender.org/api/current/bpy.types.Short2Attribute.html))
+  - `STRING` — text strings ([`StringAttribute`](https://docs.blender.org/api/current/bpy.types.StringAttribute.html)).
+    String support is *experimental* and raises a warning when used: string
+    attributes are accessible through the Python API but are not yet properly
+    supported within Geometry Nodes. Values are read and written per-element
+    (as unicode numpy arrays) since Blender's `foreach_get`/`foreach_set` do not
+    support string properties.
+
+- `Attribute.storage_type`, exposing Blender 5.2's new attribute storage types
+  (`"ARRAY"` or `"SINGLE"`). `SINGLE`-storage attributes (produced by Geometry
+  Nodes for constant values) read transparently as full arrays.
+- `named_attribute(evaluate=True)` and `evaluate_object()` now work for Curves and
+  PointCloud objects, not just meshes.
+- `BlenderObject.store_named_attribute()` now returns the created or modified
+  attribute (previously returned `None`).
+
+### Changed
+
+- Results of `AttributeArray` operations (e.g. `pos + 1`, comparisons) are now
+  plain `numpy.ndarray`s, and copies (`pos.copy()`, boolean-mask indexing) are
+  detached from Blender — neither syncs back on modification. True views
+  (slices, column access) remain connected and continue to auto-sync.
+- Data is cast to the attribute's storage dtype before writing, letting Blender's
+  `foreach_set` use its fast buffer path instead of per-element iteration
+  (a significant speedup for the common case of passing float64 arrays).
+- **Breaking**: attribute type guessing for `(n, 4)` float arrays now maps to the
+  generic `FLOAT4` type instead of `FLOAT_COLOR`. To store colors or quaternions,
+  explicitly request them with e.g. `store_named_attribute(..., atype="FLOAT_COLOR")`.
+  `(n, 4)` `uint8` arrays still map to `BYTE_COLOR`.
+- Attribute type guessing for `(n, 2)` `int16` / `uint16` arrays now maps to
+  `INT16_2D` (other integer widths still map to `INT32_2D`), and string arrays
+  map to `STRING`.
+- Requires `bpy >= 5.2` (previously `>= 5.1`).
+- Improved type hints throughout the attribute module: precise `Literal` types for
+  attribute type and domain names, `tuple[int, ...]` shapes, and an immutable
+  `AttributeType` dataclass.
+
+### Fixed
+
+- Setting an existing attribute with dictionary syntax (`bob["color"] = data`) no
+  longer performs a second, redundant write with a re-guessed attribute type,
+  which could raise a type mismatch error for color and quaternion attributes.
+- `Attribute.from_array()` now triggers the same object-data refresh workaround as
+  `store_named_attribute()`, so writes through the low-level interface update
+  reliably in the viewport.
+- `repr()` of an `AttributeArray` that has lost its attribute reference no longer
+  raises an error.
+
+### Removed
+
+- **Breaking**: removed the unused legacy `AttributeTypeInfo` and `AttributeDomain`
+  classes from the public API. Use the `AttributeTypes` and `AttributeDomains`
+  enums instead.
+
+## 0.7.0 (2026-03-05)
+
+- Updated dependencies for Blender 5.1 ([#69](https://github.com/BradyAJohnston/databpy/pull/69)).
+
+## 0.6.2 (2026-03-05)
+
+- Improved typing for the attribute module ([#67](https://github.com/BradyAJohnston/databpy/pull/67)).
+- Added `move_to_collection()` for moving objects from one collection into another
+  ([#62](https://github.com/BradyAJohnston/databpy/pull/62), thanks [\@kolibril13](https://github.com/kolibril13)).
+
+## 0.6.0 (2025-11-25)
+
+- Refactored object classes around a more minimal `BlenderObjectBase`
+  ([#61](https://github.com/BradyAJohnston/databpy/pull/61),
+  [#63](https://github.com/BradyAJohnston/databpy/pull/63)).
+
+## 0.5.1 (2025-11-06)
+
+- General cleanup ([#58](https://github.com/BradyAJohnston/databpy/pull/58)).
+- Improved deduplication method ([#60](https://github.com/BradyAJohnston/databpy/pull/60)).
+
+## 0.5.0 (2025-10-25)
+
+- Better point cloud and curves support ([#57](https://github.com/BradyAJohnston/databpy/pull/57)).
+- Requires Blender >= 4.5 for compatibility with point cloud support.
+
+## 0.4.2 (2025-10-24)
+
+- Internal improvements and cleanup ([#56](https://github.com/BradyAJohnston/databpy/pull/56)).
+- Deprecated `Attribute.n_values` in favor of `Attribute.size`.
+
+## 0.4.1 (2025-10-21)
+
+- Fixed `AttributeArray.__str__` ([#55](https://github.com/BradyAJohnston/databpy/pull/55)).
+
+## 0.4.0 (2025-10-21)
+
+- Fixed integer attribute returns to be `int32` ([#54](https://github.com/BradyAJohnston/databpy/pull/54)).
+
+---
+
+For older releases, see the [GitHub releases page](https://github.com/BradyAJohnston/databpy/releases).

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -20,6 +20,11 @@ of the attribute typing system. Requires `bpy >= 5.2`.
     (as unicode numpy arrays) since Blender's `foreach_get`/`foreach_set` do not
     support string properties.
 
+- `GeometrySet`, for accessing all components of an object's evaluated geometry —
+  including multi-component Geometry Nodes outputs (mesh, point cloud, curves and
+  instances) that a normally evaluated object doesn't expose. Provides
+  `named_attribute()` / `list_attributes()` across components and an informative
+  `repr()` suited to snapshot testing.
 - `Attribute.storage_type`, exposing Blender 5.2's new attribute storage types
   (`"ARRAY"` or `"SINGLE"`). `SINGLE`-storage attributes (produced by Geometry
   Nodes for constant values) read transparently as full arrays.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,6 @@ build-backend = "uv_build"
 
 [project.optional-dependencies]
 bpy = ["bpy>=5.2"]
-dev = [
-    "fake-bpy-module",
-    "polars",
-    "quarto-cli>=1.9",
-    "quartodoc",
-    "jupyter",
-    "polars",
-    "pytest",
-    "pytest-cov"
-    ]
 
 [tool.uv.workspace]
 members = [
@@ -42,5 +32,13 @@ members = [
 
 [dependency-groups]
 dev = [
+    "fake-bpy-module",
+    "polars",
+    "quarto-cli>=1.9",
+    "quartodoc",
+    "jupyter",
+    "polars",
+    "pytest",
+    "pytest-cov",
     "nodebpy>=520.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "databpy"
-version = "0.7.0"
+version = "0.8.0"
 description = "A data-oriented wrapper library for the Blender Python API"
 readme = "README.md"
 dependencies = [
@@ -23,7 +23,7 @@ build-backend = "uv_build"
 
 
 [project.optional-dependencies]
-bpy = ["bpy>=5.1"]
+bpy = ["bpy>=5.2"]
 dev = [
     "fake-bpy-module",
     "polars",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ dev = [
 members = [
     ".",
 ]
+
+[dependency-groups]
+dev = [
+    "nodebpy>=520.8.0",
+]

--- a/src/databpy/__init__.py
+++ b/src/databpy/__init__.py
@@ -27,10 +27,8 @@ from .attribute import (
     evaluate_object,
     Attribute,
     AttributeType,
-    AttributeTypeInfo,
     AttributeTypes,
     AttributeDomains,
-    AttributeDomain,
     NamedAttributeError,
     AttributeMismatchError,
 )
@@ -65,10 +63,8 @@ __all__ = [
     "evaluate_object",
     "Attribute",
     "AttributeType",
-    "AttributeTypeInfo",
     "AttributeTypes",
     "AttributeDomains",
-    "AttributeDomain",
     "NamedAttributeError",
     "AttributeMismatchError",
 ]

--- a/src/databpy/__init__.py
+++ b/src/databpy/__init__.py
@@ -19,6 +19,7 @@ from .addon import register, unregister
 from .utils import centre, lerp
 from .collection import create_collection, move_to_collection
 from .array import AttributeArray
+from .geometry import GeometrySet
 from .attribute import (
     named_attribute,
     store_named_attribute,
@@ -56,6 +57,7 @@ __all__ = [
     "create_collection",
     "move_to_collection",
     "AttributeArray",
+    "GeometrySet",
     "named_attribute",
     "store_named_attribute",
     "remove_named_attribute",

--- a/src/databpy/array.py
+++ b/src/databpy/array.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from .attribute import Attribute, store_named_attribute
 import bpy
@@ -25,10 +27,11 @@ class AttributeArray(np.ndarray):
     Supported Types
     ---------------
     Works with all Blender attribute types:
-    - Float types: FLOAT, FLOAT2, FLOAT_VECTOR, FLOAT_COLOR, FLOAT4X4, QUATERNION
-    - Integer types: INT (int32), INT8, INT32_2D
+    - Float types: FLOAT, FLOAT2, FLOAT4, FLOAT_VECTOR, FLOAT_COLOR, FLOAT4X4, QUATERNION
+    - Integer types: INT (int32), INT8, INT16_2D, INT32_2D
     - Boolean: BOOLEAN
     - Color: BYTE_COLOR (uint8)
+    - String: STRING (synced per-element as strings don't support `foreach_set`)
 
     Attributes
     ----------
@@ -127,11 +130,33 @@ class AttributeArray(np.ndarray):
         if obj is None:
             return
 
-        self._blender_object = getattr(obj, "_blender_object", None)
-        self._attribute = getattr(obj, "_attribute", None)
-        self._attr_name = getattr(obj, "_attr_name", None)
-        # Preserve reference to the root array for syncing
-        self._root = getattr(obj, "_root", self)
+        # only views that still share memory with the source stay connected to
+        # Blender; copies (e.g. `pos.copy()`, `pos[mask]`) become detached arrays
+        # that no longer sync
+        if np.may_share_memory(self, obj):
+            self._blender_object = getattr(obj, "_blender_object", None)
+            self._attribute = getattr(obj, "_attribute", None)
+            self._attr_name = getattr(obj, "_attr_name", None)
+            # Preserve reference to the root array for syncing
+            self._root = getattr(obj, "_root", self)
+        else:
+            self._blender_object = None
+            self._attribute = None
+            self._attr_name = None
+            self._root = self
+
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
+        """Return plain numpy arrays from operations like `pos + 1`.
+
+        Only in-place operations (`pos += 1`) keep the AttributeArray type and
+        its connection to Blender - other operation results are new arrays that
+        should not sync back.
+        """
+        if out_arr is self:
+            return out_arr
+        if return_scalar:
+            return out_arr[()]
+        return np.asarray(out_arr)
 
     def __setitem__(self, key, value):
         """Set item and sync changes back to Blender."""
@@ -184,9 +209,11 @@ class AttributeArray(np.ndarray):
         API requiring the full array. For large meshes, consider batching
         multiple modifications before triggering a sync.
         """
-        if self._blender_object is None:
-            import warnings
+        if self._attribute is None:
+            # a detached copy with no linked attribute; nothing to sync
+            return
 
+        if self._blender_object is None:
             warnings.warn(
                 "AttributeArray has lost its Blender object reference. "
                 "Changes will not be synced back to Blender. This can happen "
@@ -265,7 +292,8 @@ class AttributeArray(np.ndarray):
         attr_name = getattr(self, "_attr_name", "Unknown")
         domain = getattr(self._attribute, "domain", None)
         domain_name = domain.name if domain else "Unknown"
-        atype = getattr(self._attribute, "atype", "Unknown")
+        atype = getattr(self._attribute, "atype", None)
+        type_name = atype.value if atype is not None else "Unknown"
 
         # Get object info
         obj_name = "Unknown"
@@ -285,6 +313,6 @@ class AttributeArray(np.ndarray):
 
         return (
             f"AttributeArray(name='{attr_name}', object='{obj_name}', mesh='{obj_type}', "
-            f"domain={domain_name}, type={atype.value}, shape={self.shape}, dtype={self.dtype})\n"
+            f"domain={domain_name}, type={type_name}, shape={self.shape}, dtype={self.dtype})\n"
             f"{array_repr}"
         )

--- a/src/databpy/attribute.py
+++ b/src/databpy/attribute.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Type, Literal  # type: ignore
+from typing import Literal
 import bpy
 from bpy.types import Object
 import numpy as np
@@ -14,7 +14,6 @@ PossibleAttributeTypes = (
     | bpy.types.FloatAttribute
     | bpy.types.Float2Attribute
     | bpy.types.ByteIntAttribute
-    | bpy.types.Float2Attribute
     | bpy.types.Float4x4Attribute
     | bpy.types.ByteColorAttribute
     | bpy.types.FloatColorAttribute
@@ -83,21 +82,6 @@ def list_attributes(
     return [x for x in strings if not x.startswith(".")]
 
 
-@dataclass
-class AttributeTypeInfo:
-    dname: str
-    dtype: type
-    width: int
-
-
-@dataclass
-class AttributeDomain:
-    name: DomainNames
-
-    def __str__(self):
-        return self.name
-
-
 class AttributeMismatchError(NamedAttributeError):
     """
     Exception raised when attribute data doesn't match expected dimensions or types.
@@ -144,12 +128,15 @@ class AttributeDomains(Enum):
     LAYER = "LAYER"
 
 
-@dataclass
+ValueNames = Literal["value", "vector", "color"]
+
+
+@dataclass(frozen=True)
 class AttributeType:
     type_name: AttributeTypeNames
-    value_name: str
-    dtype: Type
-    dimensions: tuple
+    value_name: ValueNames
+    dtype: type
+    dimensions: tuple[int, ...]
 
     def __str__(self) -> str:
         return self.type_name
@@ -420,7 +407,7 @@ class Attribute:
     def __init__(self, attribute: PossibleAttributeTypes):
         self.attribute = attribute
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Returns the number of attribute elements.
 
@@ -450,8 +437,8 @@ class Attribute:
 
         Returns
         -------
-        AttributeType
-            The type information of the attribute.
+        AttributeTypes
+            The enum member representing the attribute's data type.
         """
         return AttributeTypes[self.attribute.data_type]
 
@@ -462,13 +449,13 @@ class Attribute:
 
         Returns
         -------
-        AttributeDomain
-            The domain of the attribute.
+        AttributeDomains
+            The enum member representing the attribute's domain.
         """
         return AttributeDomains[self.attribute.domain]
 
     @property
-    def value_name(self) -> str:
+    def value_name(self) -> ValueNames:
         """Returns the Blender property name for accessing values (e.g., 'value', 'vector', 'color')."""
         return self.atype.value.value_name
 
@@ -478,17 +465,17 @@ class Attribute:
         return self.atype.value.dimensions == (1,)
 
     @property
-    def type_name(self) -> str:
+    def type_name(self) -> AttributeTypeNames:
         """Returns the Blender attribute type name (e.g., 'FLOAT_VECTOR', 'INT', 'BOOLEAN')."""
         return self.atype.value.type_name
 
     @property
-    def shape(self) -> tuple:
+    def shape(self) -> tuple[int, ...]:
         """Returns the full shape of the attribute array including element dimensions."""
         return (len(self), *self.atype.value.dimensions)
 
     @property
-    def dtype(self) -> Type:
+    def dtype(self) -> type:
         """Returns the numpy dtype for this attribute type."""
         return self.atype.value.dtype
 
@@ -506,7 +493,7 @@ class Attribute:
     @property
     def size(self) -> int:
         """Returns the total number of scalar values in the attribute."""
-        return np.prod(self.shape, dtype=int)
+        return int(np.prod(self.shape, dtype=int))
 
     def from_array(self, array: np.ndarray) -> None:
         """
@@ -555,14 +542,14 @@ class Attribute:
         else:
             return array.reshape(self.shape)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Attribute: {}, type: {}, size: {}".format(
             self.attribute.name, self.type_name, self.shape
         )
 
 
 def _match_atype(
-    atype: str | AttributeTypes | None, data: np.ndarray
+    atype: AttributeTypeNames | AttributeTypes | None, data: np.ndarray
 ) -> AttributeTypes:
     if isinstance(atype, str):
         try:
@@ -576,21 +563,15 @@ def _match_atype(
     return atype
 
 
-def _match_domain(
-    domain: DomainNames | AttributeDomains | None,
-) -> DomainNames:
-    if isinstance(domain, str):
-        try:
-            AttributeDomains[domain]  # Validate the string is a valid domain
-            return domain
-        except KeyError:
-            raise ValueError(
-                f"Given domain {domain=} does not match any of the possible attribute domains: {list(AttributeDomains)=}"
-            )
-    if domain is None:
-        return AttributeDomains.POINT.value
+def _match_domain(domain: DomainNames | AttributeDomains) -> DomainNames:
     if isinstance(domain, AttributeDomains):
         return domain.value
+    try:
+        AttributeDomains[domain]  # Validate the string is a valid domain
+    except KeyError:
+        raise ValueError(
+            f"Given domain {domain=} does not match any of the possible attribute domains: {list(AttributeDomains)=}"
+        )
     return domain
 
 
@@ -653,10 +634,7 @@ def store_named_attribute(
     atype = _match_atype(atype, data)
     domain = _match_domain(domain)
 
-    if isinstance(obj, bpy.types.Object):
-        obj_data = obj.data
-    else:
-        obj_data = obj.data
+    obj_data = obj.data
 
     if not isinstance(
         obj_data, (bpy.types.Mesh, bpy.types.Curves, bpy.types.PointCloud)
@@ -668,12 +646,10 @@ def store_named_attribute(
     if name == "":
         raise NamedAttributeError("Attribute name cannot be an empty string.")
 
-    attribute: PossibleAttributeTypes = obj_data.attributes.get(name)  # type: ignore
+    attribute: PossibleAttributeTypes | None = obj_data.attributes.get(name)  # type: ignore
     if not attribute or not overwrite:
         current_names = obj_data.attributes.keys()
-        attribute: PossibleAttributeTypes = obj_data.attributes.new(  # type: ignore
-            name, atype.value.type_name, domain
-        )
+        attribute = obj_data.attributes.new(name, atype.value.type_name, domain)  # type: ignore
 
         if attribute is None:
             [
@@ -779,7 +755,7 @@ def evaluate_object(
 
 
 def named_attribute(
-    obj: bpy.types.Object, name="position", evaluate=False
+    obj: bpy.types.Object, name: str = "position", evaluate: bool = False
 ) -> np.ndarray:
     """
     Get the named attribute data from the object.
@@ -832,7 +808,7 @@ def named_attribute(
     return attr.as_array()
 
 
-def remove_named_attribute(obj: bpy.types.Object, name: str):
+def remove_named_attribute(obj: bpy.types.Object, name: str) -> None:
     """
     Remove a named attribute from an object.
 

--- a/src/databpy/attribute.py
+++ b/src/databpy/attribute.py
@@ -11,28 +11,35 @@ PossibleAttributeTypes = (
     bpy.types.IntAttribute
     | bpy.types.BoolAttribute
     | bpy.types.Int2Attribute
+    | bpy.types.Short2Attribute
     | bpy.types.FloatAttribute
     | bpy.types.Float2Attribute
+    | bpy.types.Float4Attribute
     | bpy.types.ByteIntAttribute
     | bpy.types.Float4x4Attribute
     | bpy.types.ByteColorAttribute
     | bpy.types.FloatColorAttribute
     | bpy.types.QuaternionAttribute
     | bpy.types.FloatVectorAttribute
+    | bpy.types.StringAttribute
 )
 DomainNames = Literal["POINT", "EDGE", "FACE", "CORNER", "CURVE", "INSTANCE", "LAYER"]
+StorageTypeNames = Literal["ARRAY", "SINGLE"]
 AttributeTypeNames = Literal[
     "FLOAT",
     "FLOAT_VECTOR",
     "FLOAT2",
+    "FLOAT4",
     "FLOAT_COLOR",
     "BYTE_COLOR",
     "QUATERNION",
     "INT",
     "INT8",
+    "INT16_2D",
     "INT32_2D",
     "FLOAT4X4",
     "BOOLEAN",
+    "STRING",
 ]
 
 
@@ -57,11 +64,6 @@ def _check_obj_attributes(obj: Object) -> None:
         raise TypeError(
             f"The object is not a compatible type.\n- Obj: {obj}\n- Compatible Types: {COMPATIBLE_TYPES}"
         )
-
-
-def _check_is_mesh(obj: Object) -> None:
-    if not isinstance(obj.data, bpy.types.Mesh):
-        raise TypeError("Object must be a mesh to evaluate the modifiers")
 
 
 def list_attributes(
@@ -168,6 +170,9 @@ class AttributeTypes(Enum):
     FLOAT2 : AttributeType
         2D vector of floats with dimensions (2,). Dtype: np.float32
         [More Info](https://docs.blender.org/api/current/bpy.types.Float2Attribute.html#bpy.types.Float2Attribute)
+    FLOAT4 : AttributeType
+        4D vector of floats with dimensions (4,). Dtype: np.float32
+        [More Info](https://docs.blender.org/api/current/bpy.types.Float4Attribute.html#bpy.types.Float4Attribute)
     FLOAT_COLOR : AttributeType
         RGBA color values as floats with dimensions (4,). Dtype: np.float32
         [More Info](https://docs.blender.org/api/current/bpy.types.FloatColorAttributeValue.html#bpy.types.FloatColorAttributeValue)
@@ -183,6 +188,9 @@ class AttributeTypes(Enum):
     INT8 : AttributeType
         8-bit signed integer value with dimensions (1,). Dtype: np.int8
         [More Info](https://docs.blender.org/api/current/bpy.types.ByteIntAttributeValue.html#bpy.types.ByteIntAttributeValue)
+    INT16_2D : AttributeType
+        2D vector of 16-bit signed integers with dimensions (2,). Dtype: np.int16
+        [More Info](https://docs.blender.org/api/current/bpy.types.Short2Attribute.html#bpy.types.Short2Attribute)
     INT32_2D : AttributeType
         2D vector of 32-bit integers with dimensions (2,). Dtype: np.int32
         [More Info](https://docs.blender.org/api/current/bpy.types.Int2Attribute.html#bpy.types.Int2Attribute)
@@ -192,6 +200,12 @@ class AttributeTypes(Enum):
     BOOLEAN : AttributeType
         Single boolean value with dimensions (1,). Dtype: bool
         [More Info](https://docs.blender.org/api/current/bpy.types.BoolAttribute.html#bpy.types.BoolAttribute)
+    STRING : AttributeType
+        Text string value with dimensions (1,). Dtype: np.str_. Stored by Blender as
+        bytes, and read/written per-element as `foreach_get`/`foreach_set` do not
+        support string properties. Experimental: string attributes are not yet properly
+        supported within Geometry Nodes, so using them raises a warning for now.
+        [More Info](https://docs.blender.org/api/current/bpy.types.StringAttribute.html#bpy.types.StringAttribute)
     """
 
     # CD_PROP_FLOAT (10): stored as float (MFloatProperty.f)
@@ -205,6 +219,10 @@ class AttributeTypes(Enum):
     # CD_PROP_FLOAT2 (49): stored as float[2] (blender::float2)
     FLOAT2 = AttributeType(
         type_name="FLOAT2", value_name="vector", dtype=np.float32, dimensions=(2,)
+    )
+    # CD_PROP_FLOAT4: stored as float[4] (blender::float4)
+    FLOAT4 = AttributeType(
+        type_name="FLOAT4", value_name="vector", dtype=np.float32, dimensions=(4,)
     )
     # CD_PROP_COLOR (47): stored as float[4] (MPropCol.color, ColorGeometry4f = ColorSceneLinear4f<Premultiplied>)
     # alternatively use color_srgb to get the color info in sRGB color space, otherwise linear color space
@@ -227,6 +245,10 @@ class AttributeTypes(Enum):
     INT8 = AttributeType(
         type_name="INT8", value_name="value", dtype=np.int8, dimensions=(1,)
     )
+    # CD_PROP_INT16_2D: stored as int16_t[2] (blender::short2 = VecBase<int16_t, 2>)
+    INT16_2D = AttributeType(
+        type_name="INT16_2D", value_name="value", dtype=np.int16, dimensions=(2,)
+    )
     # CD_PROP_INT32_2D (46): stored as int32_t[2] (blender::int2 = VecBase<int32_t, 2>)
     INT32_2D = AttributeType(
         type_name="INT32_2D", value_name="value", dtype=np.int32, dimensions=(2,)
@@ -239,6 +261,10 @@ class AttributeTypes(Enum):
     BOOLEAN = AttributeType(
         type_name="BOOLEAN", value_name="value", dtype=bool, dimensions=(1,)
     )
+    # CD_PROP_STRING (12): stored as MStringProperty (byte string)
+    STRING = AttributeType(
+        type_name="STRING", value_name="value", dtype=np.str_, dimensions=(1,)
+    )
 
 
 def guess_atype_from_array(array: np.ndarray) -> AttributeTypes:
@@ -247,10 +273,12 @@ def guess_atype_from_array(array: np.ndarray) -> AttributeTypes:
 
     This function matches arrays broadly to Blender attribute types while ensuring
     they are categorized correctly based on both shape and dtype. It handles:
-    - Integer types: distinguishes int8, int32, and int32_2d based on dtype and shape
+    - Integer types: distinguishes int8, int32, int16_2d and int32_2d based on dtype and shape
     - Float types: all floating point arrays map to float32-based attributes
-    - Color types: distinguishes BYTE_COLOR (uint8) from FLOAT_COLOR (float32)
+    - 4D data: uint8 maps to BYTE_COLOR, other dtypes map to the generic FLOAT4.
+      FLOAT_COLOR and QUATERNION must be explicitly requested via `atype`
     - Boolean types: maps bool arrays to BOOLEAN attributes
+    - String types: maps string arrays to STRING attributes
 
     Parameters
     ----------
@@ -300,11 +328,16 @@ def guess_atype_from_array(array: np.ndarray) -> AttributeTypes:
         # Float arrays
         elif np.issubdtype(dtype, np.floating):
             return AttributeTypes.FLOAT
+        # String arrays (unicode, bytes or numpy 2.x StringDType)
+        elif dtype.kind in ("U", "S", "T"):
+            return AttributeTypes.STRING
 
     # Handle 2D arrays (vectors, colors, matrices)
     elif shape == (n_row, 2):
-        # 2D vectors - check dtype to determine int32_2d vs float2
+        # 2D vectors - check dtype to determine int16_2d / int32_2d vs float2
         if np.issubdtype(dtype, np.integer):
+            if dtype in (np.int16, np.uint16):
+                return AttributeTypes.INT16_2D
             return AttributeTypes.INT32_2D
         elif np.issubdtype(dtype, np.floating):
             return AttributeTypes.FLOAT2
@@ -314,12 +347,12 @@ def guess_atype_from_array(array: np.ndarray) -> AttributeTypes:
         return AttributeTypes.FLOAT_VECTOR
 
     elif shape == (n_row, 4):
-        # 4D data - distinguish between BYTE_COLOR and FLOAT_COLOR based on dtype
+        # 4D data - uint8 maps to BYTE_COLOR, everything else to the generic FLOAT4.
+        # The color and quaternion types must be explicitly requested via `atype`
         if dtype == np.uint8:
             return AttributeTypes.BYTE_COLOR
         else:
-            # All other types (float32, float64, int, etc.) default to FLOAT_COLOR
-            return AttributeTypes.FLOAT_COLOR
+            return AttributeTypes.FLOAT4
 
     # Handle 3D arrays (matrices)
     elif shape == (n_row, 4, 4):
@@ -327,6 +360,52 @@ def guess_atype_from_array(array: np.ndarray) -> AttributeTypes:
 
     # Default fallback
     return AttributeTypes.FLOAT
+
+
+def _trigger_data_update(obj_data) -> None:
+    # The updating of data doesn't work 100% of the time (see:
+    # https://projects.blender.org/blender/blender/issues/118507) so this resetting of a
+    # single vertex is the current fix. Not great as I can see it breaking when we are
+    # missing a vertex - but for now we shouldn't be dealing with any situations where this
+    # is the case For now we will set a single vert to it's own position, which triggers a
+    # proper refresh of the object data.
+    try:
+        obj_data.vertices[0].co = obj_data.vertices[0].co
+    except AttributeError:
+        # For non-mesh objects (Curves, PointCloud), try update() if it exists
+        try:
+            obj_data.attributes["position"].data[0].vector = (
+                obj_data.attributes["position"].data[0].vector
+            )
+        except AttributeError:
+            if hasattr(obj_data, "update"):
+                obj_data.update()
+
+
+def _warn_string_support() -> None:
+    # STRING attributes are accessible through the Python API but aren't yet properly
+    # supported in Geometry Nodes, so treat their use as experimental for now
+    warnings.warn(
+        "String attributes can be read and written through the Python API but are not "
+        "yet properly supported within Geometry Nodes. Support may change in future "
+        "Blender / databpy versions.",
+        stacklevel=4,
+    )
+
+
+def _read_string_values(attribute: bpy.types.StringAttribute) -> np.ndarray:
+    # STRING attributes don't support `foreach_get` so values are read individually.
+    # Blender stores byte strings, which are decoded to a unicode string array
+    _warn_string_support()
+    return np.array([item.value.decode("utf-8") for item in attribute.data])
+
+
+def _write_string_values(attribute: bpy.types.StringAttribute, array: np.ndarray) -> None:
+    # STRING attributes don't support `foreach_set` so values are set individually.
+    # Blender only accepts bytes, so unicode values are encoded first
+    _warn_string_support()
+    for item, value in zip(attribute.data, np.ravel(array)):
+        item.value = value.encode("utf-8") if isinstance(value, str) else bytes(value)
 
 
 class Attribute:
@@ -470,6 +549,17 @@ class Attribute:
         return self.atype.value.type_name
 
     @property
+    def storage_type(self) -> StorageTypeNames:
+        """
+        Returns how Blender stores the attribute internally (new in Blender 5.2).
+
+        'ARRAY' is a full array of values, while 'SINGLE' is a single value for the
+        entire domain (which can appear on evaluated geometry from Geometry Nodes).
+        Reading is transparent either way - `data` exposes the full domain length.
+        """
+        return self.attribute.storage_type
+
+    @property
     def shape(self) -> tuple[int, ...]:
         """Returns the full shape of the attribute array including element dimensions."""
         return (len(self), *self.atype.value.dimensions)
@@ -519,7 +609,16 @@ class Attribute:
                 f"Array shape {array.shape} cannot be reshaped to attribute shape {self.shape}"
             )
 
-        self.attribute.data.foreach_set(self.value_name, np.ravel(array))  # type: ignore
+        if self.atype == AttributeTypes.STRING:
+            _write_string_values(self.attribute, array)  # type: ignore
+        else:
+            # casting to the storage dtype lets 'foreach_set' use the fast buffer
+            # protocol path instead of per-item iteration
+            self.attribute.data.foreach_set(  # type: ignore
+                self.value_name, np.ravel(array).astype(self.dtype, copy=False)
+            )
+
+        _trigger_data_update(self.attribute.id_data)
 
     def as_array(self) -> np.ndarray:
         """
@@ -530,6 +629,9 @@ class Attribute:
         np.ndarray
             Array containing the attribute data with appropriate shape and dtype.
         """
+
+        if self.atype == AttributeTypes.STRING:
+            return _read_string_values(self.attribute)  # type: ignore
 
         # initialize empty 1D array that is needed to then be filled with values
         # from the Blender attribute
@@ -690,27 +792,17 @@ def store_named_attribute(
             f"Attribute being written to: `{attribute.name}` of type `{target_atype.value.type_name}` does not match the type for the given data: `{atype.value.type_name}`"
         )
 
-    # the 'foreach_set' requires a 1D array, regardless of the shape of the attribute
-    # so we have to flatten it first
-    attribute.data.foreach_set(atype.value.value_name, np.ravel(data))  # type: ignore
+    if atype == AttributeTypes.STRING:
+        _write_string_values(attribute, data)  # type: ignore
+    else:
+        # the 'foreach_set' requires a 1D array, regardless of the shape of the attribute
+        # so we have to flatten it first. Casting to the attribute's storage dtype lets
+        # 'foreach_set' use the fast buffer protocol path instead of per-item iteration
+        attribute.data.foreach_set(  # type: ignore
+            atype.value.value_name, np.ravel(data).astype(atype.value.dtype, copy=False)
+        )
 
-    # The updating of data doesn't work 100% of the time (see:
-    # https://projects.blender.org/blender/blender/issues/118507) so this resetting of a
-    # single vertex is the current fix. Not great as I can see it breaking when we are
-    # missing a vertex - but for now we shouldn't be dealing with any situations where this
-    # is the case For now we will set a single vert to it's own position, which triggers a
-    # proper refresh of the object data.
-    try:
-        obj_data.vertices[0].co = obj.data.vertices[0].co  # type: ignore
-    except AttributeError:
-        # For non-mesh objects (Curves, PointCloud), try update() if it exists
-        try:
-            obj_data.attributes["position"].data[0].vector = (  # type: ignore
-                obj_data.attributes["position"].data[0].vector  # type: ignore
-            )
-        except AttributeError:
-            if hasattr(obj.data, "update"):
-                obj_data.update()  # type: ignore
+    _trigger_data_update(obj_data)
 
     return attribute
 
@@ -749,7 +841,7 @@ def evaluate_object(
     """
     if context is None:
         context = bpy.context
-    _check_is_mesh(obj)
+    _check_obj_attributes(obj)
     obj.update_tag()
     return obj.evaluated_get(context.evaluated_depsgraph_get())  # type: ignore
 
@@ -795,8 +887,6 @@ def named_attribute(
     _check_obj_attributes(obj)
 
     if evaluate:
-        _check_is_mesh(obj)
-
         obj = evaluate_object(obj)
 
     try:

--- a/src/databpy/attribute.py
+++ b/src/databpy/attribute.py
@@ -400,7 +400,9 @@ def _read_string_values(attribute: bpy.types.StringAttribute) -> np.ndarray:
     return np.array([item.value.decode("utf-8") for item in attribute.data])
 
 
-def _write_string_values(attribute: bpy.types.StringAttribute, array: np.ndarray) -> None:
+def _write_string_values(
+    attribute: bpy.types.StringAttribute, array: np.ndarray
+) -> None:
     # STRING attributes don't support `foreach_set` so values are set individually.
     # Blender only accepts bytes, so unicode values are encoded first
     _warn_string_support()
@@ -495,7 +497,7 @@ class Attribute:
         int
             The number of elements in the attribute.
         """
-        return len(self.attribute.data)  # type: ignore
+        return len(self.attribute.data)
 
     @property
     def name(self) -> str:
@@ -610,11 +612,11 @@ class Attribute:
             )
 
         if self.atype == AttributeTypes.STRING:
-            _write_string_values(self.attribute, array)  # type: ignore
+            _write_string_values(self.attribute, array)
         else:
             # casting to the storage dtype lets 'foreach_set' use the fast buffer
             # protocol path instead of per-item iteration
-            self.attribute.data.foreach_set(  # type: ignore
+            self.attribute.data.foreach_set(
                 self.value_name, np.ravel(array).astype(self.dtype, copy=False)
             )
 
@@ -631,12 +633,12 @@ class Attribute:
         """
 
         if self.atype == AttributeTypes.STRING:
-            return _read_string_values(self.attribute)  # type: ignore
+            return _read_string_values(self.attribute)
 
         # initialize empty 1D array that is needed to then be filled with values
         # from the Blender attribute
         array = np.zeros(self.size, dtype=self.dtype)
-        self.attribute.data.foreach_get(self.value_name, array)  # type: ignore
+        self.attribute.data.foreach_get(self.value_name, array)
 
         # if the attribute has more than one dimension reshape the array before returning
         if self.is_1d:
@@ -748,7 +750,7 @@ def store_named_attribute(
     if name == "":
         raise NamedAttributeError("Attribute name cannot be an empty string.")
 
-    attribute: PossibleAttributeTypes | None = obj_data.attributes.get(name)  # type: ignore
+    attribute: PossibleAttributeTypes | None = obj_data.attributes.get(name)
     if not attribute or not overwrite:
         current_names = obj_data.attributes.keys()
         attribute = obj_data.attributes.new(name, atype.value.type_name, domain)  # type: ignore
@@ -758,7 +760,7 @@ def store_named_attribute(
                 obj_data.attributes.remove(obj_data.attributes[name])
                 for name in obj_data.attributes.keys()
                 if name not in current_names
-            ]  # type: ignore
+            ]
             raise NamedAttributeError(
                 f"Could not create attribute `{name}` of type `{atype.value.type_name}` on domain `{domain}`. "
                 "Potentially the attribute name is too long or there is no geometry on the object for the given domain."
@@ -843,7 +845,7 @@ def evaluate_object(
         context = bpy.context
     _check_obj_attributes(obj)
     obj.update_tag()
-    return obj.evaluated_get(context.evaluated_depsgraph_get())  # type: ignore
+    return obj.evaluated_get(context.evaluated_depsgraph_get())
 
 
 def named_attribute(

--- a/src/databpy/geometry.py
+++ b/src/databpy/geometry.py
@@ -1,0 +1,242 @@
+from typing import Literal
+
+import bpy
+import numpy as np
+from bpy.types import Context, Object
+
+from .attribute import Attribute, NamedAttributeError
+
+GeometryComponents = Literal["MESH", "POINTCLOUD", "CURVES", "INSTANCES"]
+
+
+def _is_empty(data: bpy.types.ID) -> bool:
+    if isinstance(data, bpy.types.Mesh):
+        return len(data.vertices) == 0
+    if isinstance(data, (bpy.types.PointCloud, bpy.types.Curves)):
+        return len(data.points) == 0
+    return False
+
+
+class GeometrySet:
+    """
+    Access the evaluated geometry of an object (`bpy.types.GeometrySet`).
+
+    Evaluating an object normally only exposes a single geometry data-block, but
+    Geometry Nodes can output multiple components at once - a mesh, a point cloud,
+    curves and instances. This class evaluates the object's modifiers and provides
+    access to all of the resulting components and their attributes, which is
+    particularly useful for testing node group outputs.
+
+    Parameters
+    ----------
+    obj : bpy.types.Object
+        The Blender object to evaluate.
+    context : bpy.types.Context, optional
+        The context used to get the evaluated depsgraph. Defaults to `bpy.context`.
+
+    Attributes
+    ----------
+    object : bpy.types.Object
+        The original (unevaluated) object.
+    evaluated_object : bpy.types.Object
+        The evaluated object from the depsgraph.
+    geometry : bpy.types.GeometrySet
+        The underlying evaluated geometry.
+
+    Examples
+    --------
+    ```{python}
+    import bpy
+    import databpy as db
+
+    geom = db.GeometrySet(bpy.data.objects["Cube"])
+    geom.named_attribute("position")
+    ```
+    ```{python}
+    geom.list_attributes()
+    ```
+
+    See Also
+    --------
+    named_attribute : Read attribute data from an object's data-block
+    evaluate_object : Evaluate an object to a single data-block
+    """
+
+    def __init__(self, obj: Object, context: Context | None = None):
+        if context is None:
+            context = bpy.context
+        self.object = obj
+        depsgraph = context.evaluated_depsgraph_get()
+        self.evaluated_object: Object = depsgraph.id_eval_get(obj)
+        self.geometry = self.evaluated_object.evaluated_geometry()
+
+    @property
+    def mesh(self) -> bpy.types.Mesh | None:
+        """The mesh component of the evaluated geometry, if present."""
+        return self.geometry.mesh
+
+    @property
+    def pointcloud(self) -> bpy.types.PointCloud | None:
+        """The point cloud component of the evaluated geometry, if present."""
+        return self.geometry.pointcloud
+
+    @property
+    def curves(self) -> bpy.types.Curves | None:
+        """The curves component of the evaluated geometry, if present."""
+        return self.geometry.curves
+
+    @property
+    def volume(self) -> bpy.types.Volume | None:
+        """The volume component of the evaluated geometry, if present."""
+        return self.geometry.volume
+
+    @property
+    def grease_pencil(self) -> bpy.types.GreasePencil | None:
+        """The grease pencil component of the evaluated geometry, if present."""
+        return self.geometry.grease_pencil
+
+    @property
+    def instances(self) -> bpy.types.PointCloud | None:
+        """
+        A point cloud representation of the instances component, if present.
+
+        Each point is one instance, with attributes such as `instance_transform`
+        and `.reference_index` alongside any named attributes stored on the
+        instance domain.
+        """
+        return self.geometry.instances_pointcloud()
+
+    @property
+    def instance_references(self) -> list:
+        """The geometries, objects or collections referenced by the instances."""
+        return self.geometry.instance_references()
+
+    def components(self) -> dict[GeometryComponents, bpy.types.ID]:
+        """
+        Get the attribute-holding components present in the evaluated geometry.
+
+        Returns
+        -------
+        dict[GeometryComponents, bpy.types.ID]
+            A mapping of component names to their data-blocks, containing only
+            the components that are present and contain geometry. Blender can
+            include empty components (e.g. a 0-vertex mesh) in the evaluated
+            geometry, which are excluded here - access the `mesh` etc. properties
+            directly if you need them.
+        """
+        possible: dict[GeometryComponents, bpy.types.ID | None] = {
+            "MESH": self.mesh,
+            "POINTCLOUD": self.pointcloud,
+            "CURVES": self.curves,
+            "INSTANCES": self.instances,
+        }
+        return {
+            name: data
+            for name, data in possible.items()
+            if data is not None and not _is_empty(data)
+        }
+
+    def _get_component(self, component: GeometryComponents) -> bpy.types.ID:
+        components = self.components()
+        try:
+            return components[component]
+        except KeyError:
+            raise NamedAttributeError(
+                f"No {component} component in the evaluated geometry. "
+                f"Present components: {list(components)}"
+            )
+
+    def list_attributes(
+        self, drop_hidden: bool = False
+    ) -> dict[GeometryComponents, list[str]]:
+        """
+        List the attribute names on each component of the evaluated geometry.
+
+        Parameters
+        ----------
+        drop_hidden : bool, optional
+            Whether to drop hidden attributes (those starting with a dot).
+            Defaults to False.
+
+        Returns
+        -------
+        dict[GeometryComponents, list[str]]
+            A mapping of component names to their sorted attribute names.
+        """
+        return {
+            name: sorted(
+                key
+                for key in data.attributes.keys()
+                if not (drop_hidden and key.startswith("."))
+            )
+            for name, data in self.components().items()
+        }
+
+    def named_attribute(
+        self, name: str, component: GeometryComponents | None = None
+    ) -> np.ndarray:
+        """
+        Get named attribute data from the evaluated geometry.
+
+        Parameters
+        ----------
+        name : str
+            The name of the attribute.
+        component : GeometryComponents, optional
+            The component to read the attribute from. If None, the components are
+            searched in order (MESH, POINTCLOUD, CURVES, INSTANCES) and the first
+            that has the attribute is used.
+
+        Returns
+        -------
+        np.ndarray
+            The attribute data as a numpy array.
+
+        Raises
+        ------
+        NamedAttributeError
+            If the attribute does not exist on the given (or any) component.
+        """
+        if component is None:
+            for data in self.components().values():
+                if name in data.attributes:
+                    return Attribute(data.attributes[name]).as_array()
+            raise NamedAttributeError(
+                f"The attribute '{name}' does not exist on any component of the "
+                f"evaluated geometry. Available attributes: {self.list_attributes()}"
+            )
+
+        data = self._get_component(component)
+        try:
+            attribute = data.attributes[name]
+        except KeyError:
+            raise NamedAttributeError(
+                f"The attribute '{name}' does not exist on the {component} component. "
+                f"Available attributes: {sorted(data.attributes.keys())}"
+            )
+        return Attribute(attribute).as_array()
+
+    def __repr__(self) -> str:
+        lines = [f"GeometrySet of '{self.object.name}'"]
+        for name, data in self.components().items():
+            if isinstance(data, bpy.types.Mesh):
+                counts = (
+                    f"{len(data.vertices)} verts, {len(data.edges)} edges, "
+                    f"{len(data.polygons)} faces"
+                )
+            elif "position" in data.attributes:
+                counts = f"{len(data.attributes['position'].data)} points"
+            else:
+                counts = "empty"
+            attr_names = ", ".join(
+                sorted(key for key in data.attributes.keys() if not key.startswith("."))
+            )
+            lines.append(f"  {name}: {counts}")
+            lines.append(f"    attributes: {attr_names}")
+        for name, data in (
+            ("VOLUME", self.volume),
+            ("GREASE_PENCIL", self.grease_pencil),
+        ):
+            if data is not None:
+                lines.append(f"  {name}: present")
+        return "\n".join(lines)

--- a/src/databpy/object.py
+++ b/src/databpy/object.py
@@ -316,7 +316,7 @@ class BlenderObjectAttribute(BlenderObjectBase):
         name: str,
         atype: AttributeTypeNames | AttributeTypes | None = None,
         domain: DomainNames | AttributeDomains = AttributeDomains.POINT,
-    ) -> None:
+    ) -> bpy.types.Attribute:
         """
         Store a named attribute on the Blender object.
 
@@ -332,9 +332,14 @@ class BlenderObjectAttribute(BlenderObjectBase):
             input array.
         domain : str or AttributeDomains, optional
             The domain to store the attribute on. Defaults to AttributeDomains.POINT.
+
+        Returns
+        -------
+        bpy.types.Attribute
+            The added or modified attribute.
         """
         self._check_obj()
-        attr.store_named_attribute(
+        return attr.store_named_attribute(
             self.object, data=data, name=name, atype=atype, domain=domain
         )
 
@@ -535,7 +540,8 @@ class BlenderObjectAttribute(BlenderObjectBase):
             self.store_named_attribute(
                 data=data, name=name, domain=att.domain, atype=att.atype
             )
-        self.store_named_attribute(data=data, name=name)
+        else:
+            self.store_named_attribute(data=data, name=name)
 
     def _check_obj(self) -> None:
         _check_obj_attributes(self.object)

--- a/src/databpy/object.py
+++ b/src/databpy/object.py
@@ -326,16 +326,12 @@ class BlenderObjectAttribute(BlenderObjectBase):
             The data to be stored as an attribute.
         name : str
             The name for the attribute. Will overwrite an already existing attribute.
-        atype : str or AttributeType or None, optional
+        atype : str or AttributeTypes or None, optional
             The attribute type to store the data as. Either string or selection from the
             AttributeTypes enum. None will attempt to infer the attribute type from the
             input array.
-        domain : str or AttributeDomain, optional
-            The domain to store the attribute on. Defaults to Domains.POINT.
-
-        Returns
-        -------
-        self
+        domain : str or AttributeDomains, optional
+            The domain to store the attribute on. Defaults to AttributeDomains.POINT.
         """
         self._check_obj()
         attr.store_named_attribute(

--- a/src/databpy/object.py
+++ b/src/databpy/object.py
@@ -397,7 +397,7 @@ class BlenderObjectAttribute(BlenderObjectBase):
         bpy.types.Attributes
             The attributes of the Blender object.
         """
-        return self.data.attributes  # type: ignore
+        return self.data.attributes
 
     @property
     def position(self) -> AttributeArray:
@@ -482,7 +482,7 @@ class BlenderObjectAttribute(BlenderObjectBase):
             return len(self.data.points)
         elif isinstance(self.data, bpy.types.Curves):
             if "position" in self.data.attributes:
-                return len(self.data.attributes["position"].data)  # type: ignore
+                return len(self.data.attributes["position"].data)
             return 0
         else:
             raise TypeError(
@@ -536,7 +536,7 @@ class BlenderObjectAttribute(BlenderObjectBase):
             The data to store in the attribute.
         """
         if name in self.list_attributes():
-            att = Attribute(self.attributes[name])  # type: ignore
+            att = Attribute(self.attributes[name])
             self.store_named_attribute(
                 data=data, name=name, domain=att.domain, atype=att.atype
             )

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -560,3 +560,42 @@ def test_position_array_integration():
     tracked_pos += 0.5
     updated = tracked_bob.named_attribute("position")
     assert np.all(updated >= 0.5)
+
+
+def test_operations_return_plain_arrays():
+    """Results of operations like `pos + 1` are plain arrays detached from Blender."""
+    obj = db.create_object(np.random.rand(10, 3), name="TestOps")
+    pos = AttributeArray(obj, "position")
+    before = db.named_attribute(obj, "position")
+
+    result = pos + 1.0
+    assert not isinstance(result, AttributeArray)
+    assert isinstance(result, np.ndarray)
+
+    # modifying the result must not write back to Blender
+    result[:] = 0.0
+    np.testing.assert_array_equal(db.named_attribute(obj, "position"), before)
+
+
+def test_copies_are_detached():
+    """Copies of an AttributeArray no longer sync back to Blender (and don't warn)."""
+    import warnings
+
+    obj = db.create_object(np.random.rand(10, 3), name="TestCopy")
+    pos = AttributeArray(obj, "position")
+    before = db.named_attribute(obj, "position")
+
+    copied = pos.copy()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        copied[0] = [9.0, 9.0, 9.0]
+    np.testing.assert_array_equal(db.named_attribute(obj, "position"), before)
+
+    # fancy indexing also produces a detached copy
+    masked = pos[np.arange(10) < 5]
+    masked[0] = [5.0, 5.0, 5.0]
+    np.testing.assert_array_equal(db.named_attribute(obj, "position"), before)
+
+    # while true views remain connected and continue to sync
+    pos[0] = [1.0, 2.0, 3.0]
+    np.testing.assert_allclose(db.named_attribute(obj, "position")[0], [1.0, 2.0, 3.0])

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -147,16 +147,6 @@ def test_check_obj():
         db.attribute._check_obj_attributes,
         bpy.data.objects["Light"],
     )
-    assert pytest.raises(
-        TypeError,
-        db.attribute._check_is_mesh,
-        bpy.data.objects["Light"],
-    )
-    assert pytest.raises(
-        TypeError,
-        db.attribute._check_is_mesh,
-        bpy.data.objects["Camera"],
-    )
 
 
 def test_guess_attribute_type():
@@ -185,9 +175,8 @@ def test_guess_atype():
         db.attribute.AttributeTypes.FLOAT_VECTOR
         == db.attribute.guess_atype_from_array(np.zeros((10, 3)))
     )
-    assert (
-        db.attribute.AttributeTypes.FLOAT_COLOR
-        == db.attribute.guess_atype_from_array(np.zeros((10, 4)))
+    assert db.attribute.AttributeTypes.FLOAT4 == db.attribute.guess_atype_from_array(
+        np.zeros((10, 4))
     )
     assert db.attribute.AttributeTypes.FLOAT4X4 == db.attribute.guess_atype_from_array(
         np.zeros((10, 4, 4))
@@ -209,21 +198,132 @@ def test_guess_atype():
     assert db.attribute.AttributeTypes.INT32_2D == db.attribute.guess_atype_from_array(
         np.zeros((10, 2), dtype=np.int32)
     )
+    assert db.attribute.AttributeTypes.INT16_2D == db.attribute.guess_atype_from_array(
+        np.zeros((10, 2), dtype=np.int16)
+    )
 
-    # Test color types - distinguishes byte vs float based on dtype
+    # Test 4D types - uint8 maps to BYTE_COLOR, floats map to the generic FLOAT4
     assert (
         db.attribute.AttributeTypes.BYTE_COLOR
         == db.attribute.guess_atype_from_array(np.zeros((10, 4), dtype=np.uint8))
     )
-    assert (
-        db.attribute.AttributeTypes.FLOAT_COLOR
-        == db.attribute.guess_atype_from_array(np.zeros((10, 4), dtype=np.float32))
+    assert db.attribute.AttributeTypes.FLOAT4 == db.attribute.guess_atype_from_array(
+        np.zeros((10, 4), dtype=np.float32)
     )
 
     # Test boolean
     assert db.attribute.AttributeTypes.BOOLEAN == db.attribute.guess_atype_from_array(
         np.zeros(10, dtype=bool)
     )
+
+    # Test string
+    assert db.attribute.AttributeTypes.STRING == db.attribute.guess_atype_from_array(
+        np.array(["a", "b", "c"])
+    )
+    assert db.attribute.AttributeTypes.STRING == db.attribute.guess_atype_from_array(
+        np.array([b"a", b"b", b"c"])
+    )
+
+
+def test_float4_attribute():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    data = np.random.rand(4, 4).astype(np.float32)
+    # (n, 4) float arrays are guessed as the generic FLOAT4, while FLOAT_COLOR and
+    # QUATERNION must be explicitly requested
+    att = db.store_named_attribute(obj, data, "test_float4")
+    assert att.data_type == "FLOAT4"
+    np.testing.assert_array_equal(db.named_attribute(obj, "test_float4"), data)
+
+    att = db.store_named_attribute(obj, data, "test_color", atype="FLOAT_COLOR")
+    assert att.data_type == "FLOAT_COLOR"
+
+
+def test_int16_2d_attribute():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    data = np.array([[1, 2], [3, 4], [5, 6], [-7, -8]], dtype=np.int16)
+    att = db.store_named_attribute(obj, data, "test_short2")
+    assert att.data_type == "INT16_2D"
+    result = db.named_attribute(obj, "test_short2")
+    assert result.dtype == np.int16
+    np.testing.assert_array_equal(result, data)
+
+
+def test_setitem_preserves_existing_type():
+    bob = db.create_bob(np.random.rand(5, 3), name="TestObject")
+    color = np.random.rand(5, 4)
+    bob.store_named_attribute(color, "col", atype="FLOAT_COLOR")
+    # updating via dictionary syntax must keep the existing attribute type rather
+    # than re-guessing from the array (which would give FLOAT4)
+    bob["col"] = color * 0.5
+    assert bob.object.data.attributes["col"].data_type == "FLOAT_COLOR"
+    np.testing.assert_allclose(
+        db.named_attribute(bob.object, "col"), (color * 0.5).astype(np.float32)
+    )
+
+
+def test_bob_store_named_attribute_returns_attribute():
+    bob = db.create_bob(np.random.rand(5, 3), name="TestObject")
+    att = bob.store_named_attribute(np.arange(5), "test_return")
+    assert isinstance(att, bpy.types.Attribute)
+    assert att.name == "test_return"
+
+
+def test_storage_type():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    att = db.store_named_attribute(obj, np.arange(4), "test_int")
+    assert db.Attribute(att).storage_type == "ARRAY"
+
+    # a constant value stored via geometry nodes uses SINGLE storage on the
+    # evaluated geometry, which still reads transparently as a full array
+    tree = bpy.data.node_groups.new("test_gn", "GeometryNodeTree")
+    tree.interface.new_socket(
+        "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+    )
+    tree.interface.new_socket(
+        "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+    )
+    n_in = tree.nodes.new("NodeGroupInput")
+    n_out = tree.nodes.new("NodeGroupOutput")
+    store = tree.nodes.new("GeometryNodeStoreNamedAttribute")
+    store.data_type = "FLOAT"
+    store.domain = "POINT"
+    store.inputs["Name"].default_value = "const_val"
+    store.inputs["Value"].default_value = 3.5
+    tree.links.new(n_in.outputs[0], store.inputs["Geometry"])
+    tree.links.new(store.outputs[0], n_out.inputs[0])
+    obj.modifiers.new("test_gn", "NODES").node_group = tree
+
+    ev = db.evaluate_object(obj)
+    assert db.Attribute(ev.data.attributes["const_val"]).storage_type == "SINGLE"
+    np.testing.assert_allclose(
+        db.named_attribute(obj, "const_val", evaluate=True), np.full(4, 3.5)
+    )
+
+
+def test_named_attribute_evaluate_pointcloud():
+    obj = db.create_pointcloud_object(np.random.rand(5, 3), name="TestPoints")
+    result = db.named_attribute(obj, "position", evaluate=True)
+    assert result.shape == (5, 3)
+
+
+def test_string_attribute():
+    obj = db.create_object(np.random.rand(3, 3), name="TestObject")
+    data = np.array(["", "hello", "üñíçødé"])
+    # string attributes are experimental (not properly supported in Geometry Nodes)
+    # so all reads and writes should raise a warning
+    with pytest.warns(UserWarning, match="String attributes"):
+        att = db.store_named_attribute(obj, data, "test_string")
+    assert att.data_type == "STRING"
+    with pytest.warns(UserWarning, match="String attributes"):
+        result = db.named_attribute(obj, "test_string")
+    assert result.tolist() == data.tolist()
+
+    # overwriting with new values through the Attribute wrapper
+    attr = db.Attribute(obj.data.attributes["test_string"])
+    with pytest.warns(UserWarning, match="String attributes"):
+        attr.from_array(np.array(["x", "y", "z"]))
+    with pytest.warns(UserWarning, match="String attributes"):
+        assert attr.as_array().tolist() == ["x", "y", "z"]
 
 
 def test_raise_error():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,94 @@
+import bpy
+import numpy as np
+import pytest
+from nodebpy import geometry as g
+
+import databpy as db
+
+
+def _add_points_and_instances_nodes(obj: bpy.types.Object) -> None:
+    """Add a modifier converting the mesh to points and cube instances."""
+    with g.tree("test_gn") as tree:
+        geo = tree.inputs.geometry()
+
+        (
+            g.JoinGeometry(
+                [
+                    g.MeshToPoints(geo),
+                    g.InstanceOnPoints(geo, instance=g.Cube()),
+                ]
+            )
+            >> tree.outputs.geometry()
+        )
+
+    obj.modifiers.new("test_gn", "NODES").node_group = tree.tree
+
+
+def test_geometry_set_mesh():
+    verts = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]], dtype=np.float32)
+    obj = db.create_object(verts, name="TestObject")
+
+    geom = db.GeometrySet(obj)
+    assert geom.mesh is not None
+    assert geom.pointcloud is None
+    assert geom.instances is None
+    assert list(geom.components()) == ["MESH"]
+    np.testing.assert_allclose(geom.named_attribute("position"), verts)
+    np.testing.assert_allclose(
+        geom.named_attribute("position", component="MESH"), verts
+    )
+
+
+def test_geometry_set_multiple_components():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    _add_points_and_instances_nodes(obj)
+
+    geom = db.GeometrySet(obj)
+    # the evaluated geometry may contain an empty mesh component, but empty
+    # components are excluded from components() and attribute access
+    assert list(geom.components()) == ["POINTCLOUD", "INSTANCES"]
+
+    pos = geom.named_attribute("position", component="POINTCLOUD")
+    assert pos.shape == (4, 3)
+
+    transforms = geom.named_attribute("instance_transform", component="INSTANCES")
+    assert transforms.shape == (4, 4, 4)
+
+    # component=None searches all components for the attribute
+    found = geom.named_attribute("instance_transform")
+    np.testing.assert_allclose(found, transforms)
+
+    assert len(geom.instance_references) == 1
+
+    listed = geom.list_attributes()
+    assert "position" in listed["POINTCLOUD"]
+    assert "instance_transform" in listed["INSTANCES"]
+    # hidden attributes like .reference_index can be dropped
+    hidden_dropped = geom.list_attributes(drop_hidden=True)
+    assert not any(
+        name.startswith(".") for names in hidden_dropped.values() for name in names
+    )
+
+
+def test_geometry_set_errors():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    geom = db.GeometrySet(obj)
+
+    with pytest.raises(db.NamedAttributeError, match="does not exist on any"):
+        geom.named_attribute("nonexistent")
+
+    with pytest.raises(db.NamedAttributeError, match="does not exist on the MESH"):
+        geom.named_attribute("nonexistent", component="MESH")
+
+    with pytest.raises(db.NamedAttributeError, match="No POINTCLOUD component"):
+        geom.named_attribute("position", component="POINTCLOUD")
+
+
+def test_geometry_set_repr():
+    obj = db.create_object(np.random.rand(4, 3), name="TestObject")
+    _add_points_and_instances_nodes(obj)
+
+    text = repr(db.GeometrySet(obj))
+    assert "GeometrySet of 'TestObject'" in text
+    assert "POINTCLOUD: 4 points" in text
+    assert "INSTANCES: 4 points" in text

--- a/uv.lock
+++ b/uv.lock
@@ -177,19 +177,33 @@ css = [
 
 [[package]]
 name = "bpy"
-version = "5.1.0"
+version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cattrs" },
     { name = "cython" },
     { name = "numpy" },
     { name = "requests" },
     { name = "zstandard" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/58/e311ab21cd4347685035cb43def43e9aff32e870f65da791bb8ed666b8d7/bpy-5.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:79cb379d32432031b31aaa740b2af1cbd6fab14ba3aa25db1500b19ea332bf8a", size = 238523944, upload-time = "2026-03-17T14:44:24.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b9/bcd380708380baf759bd9c422f370294ab750535c869f809b447e7836917/bpy-5.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5b557f65902e4c84caf8b413d9bc6aceb660a5ca934e65f6c16e4ee91dc4cd4f", size = 390716200, upload-time = "2026-03-17T14:45:55.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/65/a75513cbdc117238bd2dcf1fe655e05fca379577087e03144cca6b6718a5/bpy-5.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:6ee14d8b28989b911b2e921b4592d1801738d550fedbcc57f773dae589f41bb2", size = 350105048, upload-time = "2026-03-17T14:45:25.828Z" },
-    { url = "https://files.pythonhosted.org/packages/76/55/970c78b4046b3020bee271f17e1cd769f4edfcd9c29d8ab307e908eeddf3/bpy-5.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:7dbd29e684dd6fa6acdc11c96bdbfb43ca95576a6b00ece413d3f80b8717fc08", size = 205493452, upload-time = "2026-03-17T14:44:51.573Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3a/ebdfeedbefe18641ac541c44bbe433fa363d377fedbabf4fbabb571faf5e/bpy-5.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b5f9d4e02de90be7100494807a021b60c194c5d5315daef089213b2cdc8cd9d", size = 245126219, upload-time = "2026-07-14T12:14:33.631Z" },
+    { url = "https://files.pythonhosted.org/packages/53/74/827c0930eec8d1b74b8c67d4066bf922f1e15a3d80f0f50ed4a48a2692b1/bpy-5.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:daae68954f1ab33996aa582861323eff815210e5c56641ac62f855a8365201c2", size = 401306561, upload-time = "2026-07-14T12:13:25.07Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d5/dd33167ec5540244b170a9f6ee1436e453ee89f0914401831268f69ea0bd/bpy-5.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:d657ee262bb01217343d19156c869819441b2ec436a24b302de8f1fa3a0ef1eb", size = 338722862, upload-time = "2026-07-14T12:14:14.093Z" },
+    { url = "https://files.pythonhosted.org/packages/82/cb/a8d985a59e8e31cf55f6b62144305379a4c3d795633186933059bc91c16a/bpy-5.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:925ae162a1bcde29a514804a5ef3afc5516fccc5ce568e7c8dee95d66a06215a", size = 210627206, upload-time = "2026-07-14T12:13:44.824Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -335,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "databpy"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -357,7 +371,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bpy", marker = "extra == 'bpy'", specifier = ">=5.1" },
+    { name = "bpy", marker = "extra == 'bpy'", specifier = ">=5.2" },
     { name = "fake-bpy-module", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "numpy" },
@@ -1073,9 +1087,22 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "1.26.4"
+version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+]
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -369,6 +369,11 @@ dev = [
     { name = "quartodoc" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "nodebpy" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bpy", marker = "extra == 'bpy'", specifier = ">=5.2" },
@@ -382,6 +387,9 @@ requires-dist = [
     { name = "quartodoc", marker = "extra == 'dev'" },
 ]
 provides-extras = ["bpy", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "nodebpy", specifier = ">=520.8.0" }]
 
 [[package]]
 name = "debugpy"
@@ -1055,6 +1063,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nodebpy"
+version = "520.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/9b/647f9b5b17d24c51a964630e26269df9c058f6fca467b0875d6a24153a22/nodebpy-520.8.0.tar.gz", hash = "sha256:dd3601584be3c9542ed589cdde8775ea451f6789425bae4be1f727f3fe62b4cd", size = 299027, upload-time = "2026-07-17T18:03:51.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/9f/28800aac5b8f262a0dac0dabba32bc4a4471ad04a420c7c4aba45ba387c9/nodebpy-520.8.0-py3-none-any.whl", hash = "sha256:0af2774fa4bac8cf6b7d1dcea83af5064ece89270681c60e8a4cf0667e43caf4", size = 339914, upload-time = "2026-07-17T18:03:49.935Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -359,9 +359,12 @@ dependencies = [
 bpy = [
     { name = "bpy" },
 ]
+
+[package.dev-dependencies]
 dev = [
     { name = "fake-bpy-module" },
     { name = "jupyter" },
+    { name = "nodebpy" },
     { name = "polars" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -369,27 +372,24 @@ dev = [
     { name = "quartodoc" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "nodebpy" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "bpy", marker = "extra == 'bpy'", specifier = ">=5.2" },
-    { name = "fake-bpy-module", marker = "extra == 'dev'" },
-    { name = "jupyter", marker = "extra == 'dev'" },
     { name = "numpy" },
-    { name = "polars", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "quarto-cli", marker = "extra == 'dev'", specifier = ">=1.9" },
-    { name = "quartodoc", marker = "extra == 'dev'" },
 ]
-provides-extras = ["bpy", "dev"]
+provides-extras = ["bpy"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "nodebpy", specifier = ">=520.8.0" }]
+dev = [
+    { name = "fake-bpy-module" },
+    { name = "jupyter" },
+    { name = "nodebpy", specifier = ">=520.8.0" },
+    { name = "polars" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "quarto-cli", specifier = ">=1.9" },
+    { name = "quartodoc" },
+]
 
 [[package]]
 name = "debugpy"


### PR DESCRIPTION
Support for new attributes in Blender 5.2, as well as a helper wrapper for `GeometrySet` for accessing the evaluated result of a Geometry Node tree.

Also fixes some bugs and simplifies usage of Domain & Attribute enums.